### PR TITLE
Feat/server init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-MAIN_FILES = ServerGenerator_test ServerManager ServerGenerator Server utils
+MAIN_FILES = Server_test ServerManager ServerGenerator Server utils
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -4,6 +4,10 @@
 # include <string>
 # include <map>
 # include <vector>
+# include <sys/socket.h>
+# include <sys/types.h>
+# include <sys/time.h>
+# include <netinet/in.h>
 
 class Server
 {
@@ -24,6 +28,7 @@ private:
     int _request_header_limit_size;
     int _limit_client_body_size; 
     std::string _default_error_page;
+    struct sockaddr_in _server_address;
 
 public:
     /* Constructor */
@@ -38,11 +43,16 @@ public:
     const std::map<std::string, std::string> getServerConfig();
     int getServerSocket();
     /* Setter */
+    void setServerSocket();
     /* Exception */
     /* Util */
     //TODO: 구현
     // bool isValidRequest(Request);
     // Response makeResponse(Request);
+    bool init();
+
+    //NOTE: runServer 구현해야 할 듯...?
+    void runServer();
 };
 
 #endif

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,5 +1,9 @@
 #include "Server.hpp"
 
+//NOTE: 테스트용 iostream 헤더
+#include <iostream>
+
+
 /*============================================================================*/
 /****************************  Static variables  ******************************/
 /*============================================================================*/
@@ -11,6 +15,9 @@
 Server::Server(std::map<std::string, std::string>& server_config)
 : _server_config(server_config), _server_socket(-1), _client_sockets(0), _server_name(""), _host(""), _port(""), _status_code(0), _request_uri_limit_size(0), _request_header_limit_size(0), _limit_client_body_size(0), _default_error_page("")
 {
+    //NOTE: init 시 bind, listen까지 이루어짐.
+    if (!Server::init())
+        throw "Server init error";
 }
 
 /*============================================================================*/
@@ -34,9 +41,19 @@ const std::map<std::string, std::string> Server::getServerConfig()
     return (this->_server_config);
 }
 
+int Server::getServerSocket()
+{
+    return (this->_server_socket);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
+
+// void setServerSocket(int server_socket)
+// {
+//     this->_server_socket = server_socket;
+// }
 
 /*============================================================================*/
 /******************************  Exception  ***********************************/
@@ -45,3 +62,66 @@ const std::map<std::string, std::string> Server::getServerConfig()
 /*============================================================================*/
 /*********************************  Util  *************************************/
 /*============================================================================*/
+
+bool Server::init()
+{
+
+    //TODO: 0 등으로 초기화했던 private 멤버들의 값을 세팅해주어야 한다.
+    // this->_server_socket =
+    // this->_client_sockets =
+    for (auto& conf: this->_server_config)
+    {
+        if (conf.first == "server_name")
+            this->_server_name = conf.second;
+        else if (conf.first == "host")
+            this->_host = conf.second;
+        else if (conf.first == "port")
+            this->_port = conf.second;
+    }
+
+    //NOTE: Test용 cout
+    std::cout << this->_server_name << std::endl;
+    std::cout << this->_host << std::endl;
+    std::cout << this->_port << std::endl;
+
+    // this->_status_code =
+    // this->_request_uri_limit_size = 
+    // this->_request_header_limit_size =
+    // this->_limit_client_body_size =
+    // this->_default_error_page =
+
+
+    if ((this->_server_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
+    {
+        throw "Socket Error";
+        return false;
+    }
+
+    //NOTE: Test용 cout
+    std::cout << this->_server_socket << std::endl;
+
+    int option = true;
+    setsockopt(_server_socket, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(int));
+
+    //TODO: memset 구현하기
+    memset(&this->_server_address, 0, sizeof(this->_server_address));
+    this->_server_address.sin_family = AF_INET;;
+    //TODO: htonl, htons 구현
+    //NOTE: stoi 사용가능한지 확인하기
+    this->_server_address.sin_addr.s_addr = htonl(INADDR_ANY);
+    this->_server_address.sin_port = htons(stoi(this->_port));
+
+    if (bind(this->_server_socket, reinterpret_cast<struct sockaddr *>(&this->_server_address), static_cast<socklen_t>(sizeof(this->_server_address))))
+    {
+        throw "Bind error";
+        return false;
+    }
+
+    if (listen(this->_server_socket, 128) == -1)
+    {
+        throw "Listen error";
+        return false;
+    }
+
+    return true;
+}

--- a/tests/Server_test.cpp
+++ b/tests/Server_test.cpp
@@ -1,18 +1,27 @@
 #include "Server.hpp"
 #include <iostream>
+#include <exception>
 
 int main(void)
 {
-    std::map<std::string, std::string> server_config = {{"A", "123"}, {"B", "456"}};
-    Server server(server_config);
-
-    std::cout<<"Server constructor success"<<std::endl;
-    
-    const std::map<std::string, std::string> m = server.getServerConfig();
-    for (auto& kv: server.getServerConfig())
+    try
     {
-        std::cout<<"first: "<<kv.first<<"second: "<<kv.second<<std::endl;
+        std::map<std::string, std::string> server_config = {{"server_name", "sanam"}, {"host", "127.0.0.1"}, {"port", "8080"}};
+        Server server(server_config);
+
+        std::cout<<"Server constructor success"<<std::endl;
+
+        // const std::map<std::string, std::string> m = server.getServerConfig();
+        // for (auto& kv: server.getServerConfig())
+        // {
+        //     std::cout<< kv.first<<": "<<kv.second<<std::endl;
+        // }
     }
+    catch(const std::exception& e)
+    {
+        std::cerr << e.what() << '\n';
+    }
+    
 
     return (0);
 }


### PR DESCRIPTION
Server 생성자 부분 수정 및 테스트케이스 추가하여 객체가 잘 생성되는지 확인했습니다.

또한 Server::init() 함수에 private 멤버변수들을 세팅하고, 소켓 디스크립터를 생성하는 코드를 추가하였으며 이후 bind와 listen 함수를 실행하여 연결대기상태에 놓일 수 있도록 수정했습니다.

Server::runServer() 의 경우 fd_set 들을 동일하게 관리할 수 없기 때문에 ServerManager에서 각 서버의 소켓 디스크립터들을 설정해주는 것이 더 맞겠다는 판단에 추가하지 않았습니다.