### PR TITLE
Feat/server generator parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-MAIN_FILES = Server_test ServerManager ServerGenerator Server utils
+# MAIN_FILES = Server_test ServerManager ServerGenerator Server utils
+MAIN_FILES = ServerGenerator_test ServerManager ServerGenerator Server utils
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -10,7 +10,6 @@
 
 class ServerManager;
 
-// TODO 아마 이 부분은 컴파일 에러가 뜰 수 있음. -> 다중 선언?
 const int BUF_SIZE = 4096;
 
 class ServerGenerator
@@ -44,9 +43,9 @@ public:
     void generateServers(std::vector<Server *>& servers);
     // NOTE it를 레퍼런스로 넣어주는 이유는 it의 값을 다른 함수에서도 일괄적으로 움직일 수 있게 하기 위함.
     // server_config의 값을 레퍼런스로 주는 이유는 generateServers에 server_config 변수가 선언되어 있기 때문.
-    // void parseServerBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config); // 이후에 private로 바꿔주자.
-    void parseServerBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config); 
-    void parseLocationBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config);
+    void parseServerBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config, std::map<std::string, std::map<std::string, std::string> >& _locations);
+    std::map<std::string, std::string> parseLocationBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config);
+    void setLocationConfig(std::map<std::string, std::string>& location_config, std::map<std::string, std::string>& server_config);
 };
 
 #endif

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -71,12 +71,8 @@ void
 ServerManager::initServers()
 {
     ServerGenerator server_generator(this);
-    //
-    // server_generator.generateServers(this->_servers); // config파일을 순회하며 Server객체 생성 _servers.push_b
+    server_generator.generateServers(this->_servers); // config파일을 순회하며 Server객체 생성 _servers.push_b
     
-    // server_generator.parseServerBlock(); - generateServers 내부에서 실행
-    // server_generator.parseLocationBlock(); - generateServers 내부에서 실행
-
     // TODO Server가 먼저 구현되어야만 한다.
     // for (Server *server: this->_servers)
     // {

--- a/tests/ServerGenerator_test.cpp
+++ b/tests/ServerGenerator_test.cpp
@@ -6,7 +6,7 @@ int main()
     try
     {
         ServerManager sm("./tests/config_testfile");
-        ServerGenerator sg(&sm);
+        // ServerGenerator sg(&sm);
     }
     catch(const char* e)
     {

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -2,9 +2,10 @@ http {
     include       mime.types;
     server {
         listen       80;
+        root html;
         location / {
-            root   html;
             index  index.html index.htm;
+            not aaa;
         }
         location /abc {
             root  /user/sanam;
@@ -12,14 +13,14 @@ http {
         }
     }
     server {
-        listen       80;
-        location / {
+        listen       8080;
+        location /please {
             root   html;
             index  index.html index.htm;
         }
-        location /abc {
-            root  /user/sanam;
-            index  hahahoho.html;
+        location /second-second {
+            root  /user/iwoo;
+            index  html;
         }
     }
 }

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -1,7 +1,3 @@
-worker_processes  1;
-events {
-    worker_connections  1024;
-}
 http { 
     include       mime.types;
     server {
@@ -9,6 +5,21 @@ http {
         location / {
             root   html;
             index  index.html index.htm;
+        }
+        location /abc {
+            root  /user/sanam;
+            index  hahahoho.html;
+        }
+    }
+    server {
+        listen       80;
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+        location /abc {
+            root  /user/sanam;
+            index  hahahoho.html;
         }
     }
 }


### PR DESCRIPTION
서버블록과 로케이션 블록 파서 부분을 수정했습니다.

기존에는 하나의 서버에 여러 개의 로케이션 블록 내용이 들어가지 못했었습니다.

문제는 로케이션의 정보들을 저장할 변수가 없었기 떄문이었습니다.

따라서 로케이션의 정보들을 갖고 있을 변수를 하나 만들었습니다. 아래와 같습니다.
`std::map<std::string, std::map<std::string, std::string> > locations`

이 변경으로 인해 `Server` 의 생성자를 호출할 때 `Server(std::map<std::string, std::string> server_config)`에서
`Server(std::map<std::string, std::string> server_config, std::map<std::string, std::map<std::string, std::string> > locations )`로 수정이 필요해 보입니다.

그리고 http 부분의 파서는 아직 구현하지 않았습니다. 이 다음으로 구현하고 버그 픽스 진행하겠습니다.