### PR TITLE
Feat/server generator parser setter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-MAIN_FILES = Server_test ServerManager ServerGenerator Server utils
+# MAIN_FILES = Server_test ServerManager ServerGenerator Server utils
+MAIN_FILES = ServerGenerator_test ServerManager ServerGenerator Server utils
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -48,8 +48,20 @@ public:
     void setLocationConfig(location_info& location_config, server_info& server_config);
 
     server_info parseHttpBlock();
-    void parseServerBlock(std::vector<std::string>::iterator& it, server_info& server_config, std::map<std::string, location_info>& locations);
-    location_info parseLocationBlock(std::vector<std::string>::iterator& it, location_info& server_config);
+    void parseServerBlock(
+            std::vector<std::string>::iterator& it,
+            server_info& server_config,
+            std::map<std::string,
+            location_info>& locations);
+
+    location_info parseLocationBlock(
+            std::vector<std::string>::iterator& it,
+            location_info& server_config);
+
+    void (ServerGenerator::*skipServerBlock) (
+         std::vector<std::string>::iterator&,
+         server_info&,
+         std::map<std::string, location_info>&) = &ServerGenerator::parseServerBlock;
 };
 
 void testLocation(std::map<std::string, location_info>& test);

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -5,6 +5,7 @@
 # include <map>
 # include <string>
 # include <iostream>
+# include "types.hpp"
 # include "utils.hpp"
 # include "Server.hpp"
 
@@ -41,11 +42,13 @@ public:
     // bool isValidConfigFile() const; //throw
     void setGlobalConfig();
     void generateServers(std::vector<Server *>& servers);
-    // NOTE it를 레퍼런스로 넣어주는 이유는 it의 값을 다른 함수에서도 일괄적으로 움직일 수 있게 하기 위함.
-    // server_config의 값을 레퍼런스로 주는 이유는 generateServers에 server_config 변수가 선언되어 있기 때문.
-    void parseServerBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config, std::map<std::string, std::map<std::string, std::string> >& _locations);
-    std::map<std::string, std::string> parseLocationBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config);
-    void setLocationConfig(std::map<std::string, std::string>& location_config, std::map<std::string, std::string>& server_config);
+
+    void parseServerBlock(std::vector<std::string>::iterator& it, type_server& server_config, std::map<std::string, type_location>& locations);
+
+    type_location parseLocationBlock(std::vector<std::string>::iterator& it, type_location& server_config);
+
+    void setLocationConfig(type_location& location_config, type_server& server_config);
+
 };
 
 #endif

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -41,17 +41,17 @@ public:
     void convertFileToStringVector(const char *config_file_path);
     // TODO isValidConfigFile 구현하기
     // bool isValidConfigFile() const; //throw
-    void setGlobalConfig();
     void generateServers(std::vector<Server *>& servers);
 
-    void parseServerBlock(std::vector<std::string>::iterator& it, type_server& server_config, std::map<std::string, type_location>& locations);
-
-    type_location parseLocationBlock(std::vector<std::string>::iterator& it, type_location& server_config);
-
+    void setHttpConfig(type_server& http_config);
+    void setServerConfig(type_server& server_config, type_server& http_config);
     void setLocationConfig(type_location& location_config, type_server& server_config);
 
     type_server parseHttpBlock();
+    void parseServerBlock(std::vector<std::string>::iterator& it, type_server& server_config, std::map<std::string, type_location>& locations);
+    type_location parseLocationBlock(std::vector<std::string>::iterator& it, type_location& server_config);
 };
+
 void testLocation(std::map<std::string, type_location>& test);
 void testServer(type_server& test);
 

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -69,7 +69,7 @@ public:
          std::map<std::string, location_info>&) = &ServerGenerator::parseServerBlock;
 };
 
-void testLocation(std::map<std::string, location_info>& test);
-void testServer(server_info& test);
+void testLocationConfig(std::map<std::string, location_info>& test);
+void testServerConfig(server_info& test);
 
 #endif

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -43,16 +43,16 @@ public:
     // bool isValidConfigFile() const; //throw
     void generateServers(std::vector<Server *>& servers);
 
-    void setHttpConfig(type_server& http_config);
-    void setServerConfig(type_server& server_config, type_server& http_config);
-    void setLocationConfig(type_location& location_config, type_server& server_config);
+    void setHttpConfig(server_info& http_config);
+    void setServerConfig(server_info& server_config, server_info& http_config);
+    void setLocationConfig(location_info& location_config, server_info& server_config);
 
-    type_server parseHttpBlock();
-    void parseServerBlock(std::vector<std::string>::iterator& it, type_server& server_config, std::map<std::string, type_location>& locations);
-    type_location parseLocationBlock(std::vector<std::string>::iterator& it, type_location& server_config);
+    server_info parseHttpBlock();
+    void parseServerBlock(std::vector<std::string>::iterator& it, server_info& server_config, std::map<std::string, location_info>& locations);
+    location_info parseLocationBlock(std::vector<std::string>::iterator& it, location_info& server_config);
 };
 
-void testLocation(std::map<std::string, type_location>& test);
-void testServer(type_server& test);
+void testLocation(std::map<std::string, location_info>& test);
+void testServer(server_info& test);
 
 #endif

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -43,9 +43,14 @@ public:
     // bool isValidConfigFile() const; //throw
     void generateServers(std::vector<Server *>& servers);
 
-    void setHttpConfig(server_info& http_config);
-    void setServerConfig(server_info& server_config, server_info& http_config);
-    void setLocationConfig(location_info& location_config, server_info& server_config);
+    void initHttpConfig(server_info& http_config);
+    void initServerConfig(
+            server_info& server_config,
+            server_info& http_config);
+
+    void initLocationConfig(
+            location_info& location_config,
+            server_info& server_config);
 
     server_info parseHttpBlock();
     void parseServerBlock(
@@ -58,7 +63,7 @@ public:
             std::vector<std::string>::iterator& it,
             location_info& server_config);
 
-    void (ServerGenerator::*skipServerBlock) (
+    void (ServerGenerator::*skipServerBlock)(
          std::vector<std::string>::iterator&,
          server_info&,
          std::map<std::string, location_info>&) = &ServerGenerator::parseServerBlock;

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -8,6 +8,7 @@
 # include "types.hpp"
 # include "utils.hpp"
 # include "Server.hpp"
+# include <iomanip>
 
 class ServerManager;
 
@@ -49,6 +50,9 @@ public:
 
     void setLocationConfig(type_location& location_config, type_server& server_config);
 
+    type_server parseHttpBlock();
 };
+void testLocation(std::map<std::string, type_location>& test);
+void testServer(type_server& test);
 
 #endif

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -10,7 +10,6 @@
 
 class ServerManager;
 
-// TODO 아마 이 부분은 컴파일 에러가 뜰 수 있음. -> 다중 선언?
 const int BUF_SIZE = 4096;
 
 class ServerGenerator
@@ -44,9 +43,9 @@ public:
     void generateServers(std::vector<Server *>& servers);
     // NOTE it를 레퍼런스로 넣어주는 이유는 it의 값을 다른 함수에서도 일괄적으로 움직일 수 있게 하기 위함.
     // server_config의 값을 레퍼런스로 주는 이유는 generateServers에 server_config 변수가 선언되어 있기 때문.
-    // void parseServerBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config); // 이후에 private로 바꿔주자.
-    void parseServerBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config); 
-    void parseLocationBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config);
+    void parseServerBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config, std::map<std::string, std::map<std::string, std::string> >& _locations);
+    std::map<std::string, std::string> parseLocationBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config);
+    void setLocationConfig(std::map<std::string, std::string>& location_config, std::map<std::string, std::string>& server_config);
 };
 
 #endif

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -3,6 +3,10 @@
 
 # include <string>
 # include <vector>
+# include <map>
+
+using type_location = std::map<std::string, std::string>;
+using type_server = std::map<std::string, std::string>;
 
 //NOTE 임시
 typedef struct GlobalConfig

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -5,8 +5,8 @@
 # include <vector>
 # include <map>
 
-using type_location = std::map<std::string, std::string>;
-using type_server = std::map<std::string, std::string>;
+using location_info = std::map<std::string, std::string>;
+using server_info = std::map<std::string, std::string>;
 
 //NOTE 임시
 typedef struct GlobalConfig

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -90,7 +90,7 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
         if ( *it == "server {")
         {
             server_info server_config;
-            setServerConfig(server_config, http_config);
+            initServerConfig(server_config, http_config);
             it++;
             std::map<std::string, location_info> locations;
             parseServerBlock(it, server_config, locations);
@@ -111,7 +111,7 @@ ServerGenerator::parseHttpBlock()
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
     std::vector<std::string>::iterator ite = this->_configfile_lines.end();
 
-    setHttpConfig(http_config);
+    initHttpConfig(http_config);
     while (it != ite)
     {
         if (*it == "http {")
@@ -165,7 +165,7 @@ ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, serv
     std::vector<std::string> directives;
     location_info location_config;
 
-    setLocationConfig(location_config, server_config);
+    initLocationConfig(location_config, server_config);
     while (it != _configfile_lines.end())
     {
         directives = ft::split(*it, " ");
@@ -203,7 +203,7 @@ ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, serv
 }
 
 void
-ServerGenerator::setHttpConfig(server_info& http_config)
+ServerGenerator::initHttpConfig(server_info& http_config)
 {
     http_config["root"] = "html";
     http_config["index"] = "index.html";
@@ -212,7 +212,7 @@ ServerGenerator::setHttpConfig(server_info& http_config)
 }
 
 void
-ServerGenerator::setServerConfig(server_info& server_config, server_info& http_config)
+ServerGenerator::initServerConfig(server_info& server_config, server_info& http_config)
 {
     std::map<std::string, std::string>::iterator ite = http_config.end();
 
@@ -233,7 +233,7 @@ ServerGenerator::setServerConfig(server_info& server_config, server_info& http_c
 }
 
 void
-ServerGenerator::setLocationConfig(location_info& location_config, server_info& server_config)
+ServerGenerator::initLocationConfig(location_info& location_config, server_info& server_config)
 {
     std::map<std::string, std::string>::iterator ite = server_config.end();
 

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -94,8 +94,8 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
             it++;
             std::map<std::string, location_info> locations;
             parseServerBlock(it, server_config, locations);
-            testServer(server_config);
-            testLocation(locations);
+            testServerConfig(server_config);
+            testLocationConfig(locations);
             // servers.push_back(new Server(server_config, locations));
         }
         it++;
@@ -253,7 +253,7 @@ ServerGenerator::initLocationConfig(location_info& location_config, server_info&
 }
 
 /* 디버깅용 함수 */
-void testServer(server_info& test)
+void testServerConfig(server_info& test)
 {
     std::cout << "\033[1;31;40mserver config check\033[0m" << std::endl;
     for (auto& s : test)
@@ -261,7 +261,7 @@ void testServer(server_info& test)
     std::cout << "=====================================" << std::endl;
 }
 
-void testLocation(std::map<std::string, location_info>& test)
+void testLocationConfig(std::map<std::string, location_info>& test)
 {
     std::cout << "\033[1;31;40mlocation config check\033[0m" << std::endl;
     for (auto& a : test)

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -40,8 +40,8 @@ ServerGenerator::~ServerGenerator()
 
 /*============================================================================*/
 /******************************  Exception  ***********************************/
-/*============================================================================*/
 
+/*============================================================================*/
 /*============================================================================*/
 /*********************************  Util  *************************************/
 /*============================================================================*/
@@ -59,16 +59,13 @@ ServerGenerator::convertFileToStringVector(const char *config_file_path)
     if (fd < 0)
         throw (strerror(errno));
     memset(reinterpret_cast<void *>(buf), 0, BUF_SIZE);
-
     while ((readed = read(fd, reinterpret_cast<void *>(buf), BUF_SIZE)))
     {
         if (readed < 0)
             throw(strerror(errno));
         readed_string += std::string(buf);
     }
-
     lines = ft::split(readed_string, "\n");
-
     for (std::string line : lines)
     {
         std::string trimmed = ft::ltrim(ft::rtrim(line));
@@ -92,9 +89,9 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
     {
         if ( *it == "server {")
         {
-            std::map<std::string, std::string> server_config(http_config);
+            type_server server_config(http_config);
             it++;
-            std::map<std::string, std::map<std::string, std::string> > locations;
+            std::map<std::string, type_location > locations;
             parseServerBlock(it, server_config, locations);
             
             std::cout << "===============================" << std::endl;
@@ -130,7 +127,7 @@ ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, std::m
         directives = ft::split(*it, " ");
         if (directives[0] == "location")
         {
-            std::map<std::string, std::string> location_config = parseLocationBlock(it, server_config);
+            type_location location_config = parseLocationBlock(it, server_config);
             std::string temp = location_config["route"];
             locations[temp] = location_config;
             continue ;
@@ -146,7 +143,7 @@ ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, std::m
 }
 
 void
-ServerGenerator::setLocationConfig(std::map<std::string, std::string>& location_config, std::map<std::string, std::string>& server_config)
+ServerGenerator::setLocationConfig(type_location& location_config, type_server& server_config)
 {
     std::map<std::string, std::string>::iterator ite = server_config.end();
 
@@ -156,11 +153,13 @@ ServerGenerator::setLocationConfig(std::map<std::string, std::string>& location_
         location_config["root"] = server_config["root"];
 }
 
-std::map<std::string, std::string>
-ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, std::map<std::string, std::string>& server_config)
+type_location
+ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, type_server& server_config)
 {
     std::vector<std::string> directives;
-    std::map<std::string, std::string> location_config;
+    // using test = std::map<std::string, std::string>;
+    // std::map<std::string, std::string> location_config;
+    type_location location_config;
 
     setLocationConfig(location_config, server_config);
     while (it != _configfile_lines.end())

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -106,6 +106,8 @@ server_info
 ServerGenerator::parseHttpBlock()
 {
     server_info http_config;
+    server_info skip_server;
+    std::map<std::string, location_info> skip_locations;
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
     std::vector<std::string>::iterator ite = this->_configfile_lines.end();
 
@@ -126,11 +128,7 @@ ServerGenerator::parseHttpBlock()
             http_config[key] = value;
         }
         else if (*it == "server {")
-        {
-            server_info server_temp;
-            std::map<std::string, location_info> locations_temp;
-            parseServerBlock(it, server_temp, locations_temp);
-        }
+            (*this.*skipServerBlock)(it, skip_server, skip_locations);
         it++;
     }
     return (http_config);

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -77,7 +77,7 @@ ServerGenerator::convertFileToStringVector(const char *config_file_path)
 void
 ServerGenerator::generateServers(std::vector<Server *>& servers)
 {
-    type_server http_config;
+    server_info http_config;
     std::vector<std::string> directives;
     
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
@@ -89,10 +89,10 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
     {
         if ( *it == "server {")
         {
-            type_server server_config;
+            server_info server_config;
             setServerConfig(server_config, http_config);
             it++;
-            std::map<std::string, type_location> locations;
+            std::map<std::string, location_info> locations;
             parseServerBlock(it, server_config, locations);
             testServer(server_config);
             testLocation(locations);
@@ -102,10 +102,10 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
     }
 }
 
-type_server
+server_info
 ServerGenerator::parseHttpBlock()
 {
-    type_server http_config;
+    server_info http_config;
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
     std::vector<std::string>::iterator ite = this->_configfile_lines.end();
 
@@ -127,8 +127,8 @@ ServerGenerator::parseHttpBlock()
         }
         else if (*it == "server {")
         {
-            type_server server_temp;
-            std::map<std::string, type_location> locations_temp;
+            server_info server_temp;
+            std::map<std::string, location_info> locations_temp;
             parseServerBlock(it, server_temp, locations_temp);
         }
         it++;
@@ -137,7 +137,7 @@ ServerGenerator::parseHttpBlock()
 }
 
 void
-ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, type_server& server_config, std::map<std::string, type_location>& locations)
+ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, server_info& server_config, std::map<std::string, location_info>& locations)
 {
     std::vector<std::string>	directives;
 
@@ -146,7 +146,7 @@ ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, type_s
         directives = ft::split(*it, " ");
         if (directives[0] == "location")
         {
-            type_location location_config = parseLocationBlock(it, server_config);
+            location_info location_config = parseLocationBlock(it, server_config);
             std::string temp = location_config["route"];
             locations[temp] = location_config;
             continue ;
@@ -161,11 +161,11 @@ ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, type_s
     }
 }
 
-type_location
-ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, type_server& server_config)
+location_info
+ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, server_info& server_config)
 {
     std::vector<std::string> directives;
-    type_location location_config;
+    location_info location_config;
 
     setLocationConfig(location_config, server_config);
     while (it != _configfile_lines.end())
@@ -205,7 +205,7 @@ ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, type
 }
 
 void
-ServerGenerator::setHttpConfig(type_server& http_config)
+ServerGenerator::setHttpConfig(server_info& http_config)
 {
     http_config["root"] = "html";
     http_config["index"] = "index.html";
@@ -214,7 +214,7 @@ ServerGenerator::setHttpConfig(type_server& http_config)
 }
 
 void
-ServerGenerator::setServerConfig(type_server& server_config, type_server& http_config)
+ServerGenerator::setServerConfig(server_info& server_config, server_info& http_config)
 {
     std::map<std::string, std::string>::iterator ite = http_config.end();
 
@@ -235,7 +235,7 @@ ServerGenerator::setServerConfig(type_server& server_config, type_server& http_c
 }
 
 void
-ServerGenerator::setLocationConfig(type_location& location_config, type_server& server_config)
+ServerGenerator::setLocationConfig(location_info& location_config, server_info& server_config)
 {
     std::map<std::string, std::string>::iterator ite = server_config.end();
 
@@ -255,7 +255,7 @@ ServerGenerator::setLocationConfig(type_location& location_config, type_server& 
 }
 
 /* 디버깅용 함수 */
-void testServer(type_server& test)
+void testServer(server_info& test)
 {
     std::cout << "\033[1;31;40mserver config check\033[0m" << std::endl;
     for (auto& s : test)
@@ -263,13 +263,13 @@ void testServer(type_server& test)
     std::cout << "=====================================" << std::endl;
 }
 
-void testLocation(std::map<std::string, type_location>& test)
+void testLocation(std::map<std::string, location_info>& test)
 {
     std::cout << "\033[1;31;40mlocation config check\033[0m" << std::endl;
     for (auto& a : test)
     {
         std::cout << "route: " << a.first << std::endl;
-        type_location temp = a.second;
+        location_info temp = a.second;
         for (auto& b : temp)
         {
             std::cout << "key: "<< "\033[1;31;40m" << std::setw(25) << b.first << "\033[0m" <<  "||  value: " << "\033[1;34;40m" << b.second << "\033[0m" << std::endl;

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -53,7 +53,7 @@ ServerGenerator::convertFileToStringVector(const char *config_file_path)
     int	readed;
     char buf[BUF_SIZE];
     std::string readed_string;
-    std::vector<std::string> lines(100);
+    std::vector<std::string> lines;
 
     fd = open(config_file_path, O_RDONLY, 0644);
     if (fd < 0)
@@ -73,7 +73,7 @@ ServerGenerator::convertFileToStringVector(const char *config_file_path)
     {
         std::string trimmed = ft::ltrim(ft::rtrim(line));
         if (trimmed.size() > 0)
-            this->_configfile_lines.push_back(std::string(trimmed));
+            this->_configfile_lines.push_back(trimmed);
     }
 }
 
@@ -81,11 +81,10 @@ void
 ServerGenerator::generateServers(std::vector<Server *>& servers)
 {
     std::vector<std::string> directives;
-    std::map<std::string, std::string> _http_config;
+    std::map<std::string, std::string> http_config;
     
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
     std::vector<std::string>::iterator ite = this->_configfile_lines.end();
-    //TODO http_config 를 먼저 작성하자.
     // std::map<std::string, std::string> _http = httpParseBlock();
     (void)servers;
 
@@ -93,18 +92,18 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
     {
         if ( *it == "server {")
         {
-            std::map<std::string, std::string> _server_config(_http_config);
+            std::map<std::string, std::string> server_config(http_config);
             it++;
-            std::map<std::string, std::map<std::string, std::string> > _locations;
-            parseServerBlock(it, _server_config, _locations);
+            std::map<std::string, std::map<std::string, std::string> > locations;
+            parseServerBlock(it, server_config, locations);
             
             std::cout << "===============================" << std::endl;
-            for (auto& s : _server_config)
+            for (auto& s : server_config)
             {
                 std::cout << "key: " << s.first << "  value: " << s.second << std::endl;
             }
             std::cout << "==========   locations ========" << std::endl;
-            for (auto& s : _locations)
+            for (auto& s : locations)
             {
                 std::cout << "---------------------------" << std::endl;
                 std::cout << "route: " << s.first << std::endl;
@@ -114,8 +113,7 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
                 }
                 std::cout << "-----------다음----------------" << std::endl;
             }
-            //TODO  new로 해야할까?
-            // servers.push_back(new Server(_server_config, _locations));
+            // servers.push_back(new Server(server_config, locations));
             std::cout << "===============================\n\n" << std::endl;
         }
         it++;

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -89,13 +89,13 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
     {
         if ( *it == "server {")
         {
-            type_server server_config(http_config);
+            type_server server_config;
+            setServerConfig(server_config, http_config);
             it++;
             std::map<std::string, type_location> locations;
             parseServerBlock(it, server_config, locations);
-            // testLocation(locations);
             testServer(server_config);
-
+            testLocation(locations);
             // servers.push_back(new Server(server_config, locations));
         }
         it++;
@@ -109,6 +109,7 @@ ServerGenerator::parseHttpBlock()
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
     std::vector<std::string>::iterator ite = this->_configfile_lines.end();
 
+    setHttpConfig(http_config);
     while (it != ite)
     {
         if (*it == "http {")
@@ -204,33 +205,74 @@ ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, type
 }
 
 void
+ServerGenerator::setHttpConfig(type_server& http_config)
+{
+    http_config["root"] = "html";
+    http_config["index"] = "index.html";
+    http_config["autoindex"] = "off";
+    http_config["auth_basic"] = "off";
+}
+
+void
+ServerGenerator::setServerConfig(type_server& server_config, type_server& http_config)
+{
+    std::map<std::string, std::string>::iterator ite = http_config.end();
+
+    server_config["listen"] = std::to_string(8080);
+    server_config["client_max_body_size"] = std::string("1m");
+    if (http_config.find("root") != ite)
+        server_config["root"] = http_config["root"];
+    if (http_config.find("index") != ite)
+        server_config["index"] = http_config["index"];
+    if (http_config.find("autoindex") != ite)
+        server_config["autoindex"] = http_config["autoindex"];
+    if (http_config.find("auth_basic") != ite)
+        server_config["auth_basic"] = http_config["auth_basic"];
+    if (http_config.find("auth_basic_file") != ite)
+        server_config["auth_baasic_file"] = http_config["auth_basic_file"];
+    if (http_config.find("error_page") != ite)
+        server_config["error_page"] = http_config["error_page"];
+}
+
+void
 ServerGenerator::setLocationConfig(type_location& location_config, type_server& server_config)
 {
     std::map<std::string, std::string>::iterator ite = server_config.end();
 
-    if (server_config.find("index") != ite)
-        location_config["index"] = server_config["index"];
     if (server_config.find("root") != ite)
         location_config["root"] = server_config["root"];
+    if (server_config.find("index") != ite)
+        location_config["index"] = server_config["index"];
+    if (server_config.find("autoindex") != ite)
+        location_config["autoindex"] = server_config["autoindex"];
+    if (server_config.find("auth_basic") != ite)
+        location_config["auth_basic"] = server_config["auth_basic"];
+    if (server_config.find("auth_basic_file") != ite)
+        location_config["auth_baasic_file"] = server_config["auth_basic_file"];
+    if (server_config.find("error_page") != ite)
+        location_config["error_page"] = server_config["error_page"];
+
 }
 
 /* 디버깅용 함수 */
 void testServer(type_server& test)
 {
+    std::cout << "\033[1;31;40mserver config check\033[0m" << std::endl;
     for (auto& s : test)
-        std::cout << "key:" << std::setw(15) << s.first  << "||  value:" << s.second << std::endl;
+        std::cout << "key:" << "\033[1;31;40m" << std::setw(25) << s.first << "\033[0m" << "||  value:" << "\033[1;34;40m" << s.second << "\033[0m" << std::endl;
     std::cout << "=====================================" << std::endl;
 }
 
 void testLocation(std::map<std::string, type_location>& test)
 {
+    std::cout << "\033[1;31;40mlocation config check\033[0m" << std::endl;
     for (auto& a : test)
     {
         std::cout << "route: " << a.first << std::endl;
         type_location temp = a.second;
         for (auto& b : temp)
         {
-            std::cout << "key: " << std::setw(15) << b.first <<  "||  value: " << b.second << std::endl;
+            std::cout << "key: "<< "\033[1;31;40m" << std::setw(25) << b.first << "\033[0m" <<  "||  value: " << "\033[1;34;40m" << b.second << "\033[0m" << std::endl;
         }
         std::cout << "=====================================" << std::endl;
     }

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -177,9 +177,22 @@ ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, std:
             it++;
             return (location_config);
         }
-        std::string temp = ft::rtrim(directives[1], ";");
-        directives[1] = temp;
-        location_config[directives[0]] = directives[1];
+        std::string joined;
+        if (directives.size() > 2)
+        {
+            for (size_t i = 1; i < directives.size(); ++i)
+            {
+                joined += directives[i];
+                joined += " ";
+            }
+            joined = ft::rtrim(joined, "; ");
+            location_config[directives[0]] = joined;
+        }
+        else
+        {
+            std::string temp = ft::rtrim(directives[1], ";");
+            location_config[directives[0]] = temp;
+        }
         directives.clear();
         it++;
     }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -71,12 +71,8 @@ void
 ServerManager::initServers()
 {
     ServerGenerator server_generator(this);
-    //
-    // server_generator.generateServers(this->_servers); // config파일을 순회하며 Server객체 생성 _servers.push_b
+    server_generator.generateServers(this->_servers); // config파일을 순회하며 Server객체 생성 _servers.push_b
     
-    // server_generator.parseServerBlock(); - generateServers 내부에서 실행
-    // server_generator.parseLocationBlock(); - generateServers 내부에서 실행
-
     // TODO Server가 먼저 구현되어야만 한다.
     // for (Server *server: this->_servers)
     // {

--- a/tests/ServerGenerator_test.cpp
+++ b/tests/ServerGenerator_test.cpp
@@ -6,7 +6,6 @@ int main()
     try
     {
         ServerManager sm("./tests/config_testfile");
-        // ServerGenerator sg(&sm);
     }
     catch(const char* e)
     {

--- a/tests/ServerGenerator_test.cpp
+++ b/tests/ServerGenerator_test.cpp
@@ -6,7 +6,7 @@ int main()
     try
     {
         ServerManager sm("./tests/config_testfile");
-        ServerGenerator sg(&sm);
+        // ServerGenerator sg(&sm);
     }
     catch(const char* e)
     {

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -1,11 +1,12 @@
 http { 
-    include       mime.types;
+    include mime.types;
+    root /test/folder;
     server {
         listen       80;
         root html;
         location / {
             index  index.html index.htm;
-            not aaa;
+            limit_except GET POST
         }
         location /abc {
             root  /user/sanam;
@@ -15,12 +16,12 @@ http {
     server {
         listen       8080;
         location /please {
-            root   html;
             index  index.html index.htm;
         }
-        location /second-second {
+        location /only-put {
             root  /user/iwoo;
             index  html;
+            limit_except PUT
         }
     }
 }

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -2,9 +2,10 @@ http {
     include       mime.types;
     server {
         listen       80;
+        root html;
         location / {
-            root   html;
             index  index.html index.htm;
+            not aaa;
         }
         location /abc {
             root  /user/sanam;
@@ -12,14 +13,14 @@ http {
         }
     }
     server {
-        listen       80;
-        location / {
+        listen       8080;
+        location /please {
             root   html;
             index  index.html index.htm;
         }
-        location /abc {
-            root  /user/sanam;
-            index  hahahoho.html;
+        location /second-second {
+            root  /user/iwoo;
+            index  html;
         }
     }
 }

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -1,7 +1,3 @@
-worker_processes  1;
-events {
-    worker_connections  1024;
-}
 http { 
     include       mime.types;
     server {
@@ -9,6 +5,21 @@ http {
         location / {
             root   html;
             index  index.html index.htm;
+        }
+        location /abc {
+            root  /user/sanam;
+            index  hahahoho.html;
+        }
+    }
+    server {
+        listen       80;
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+        location /abc {
+            root  /user/sanam;
+            index  hahahoho.html;
         }
     }
 }


### PR DESCRIPTION
`STYLE: change variables name`
- 어제 지적 해주신 스타일들을 수정했습니다.

FIX: simple directive's several arguments …
- `index index.html index.htm` 과 같이 value의 값으로 여러 개가 들어오는 경우 처리할 수 있게 수정했습니다.

`REFACTOR: Simplified the type using 'using'`
- `using` 키워드를 사용해서 `std::map<std::string, std::string>` 을
  - `type_server` 와 `type_location` 선언 및 사용할 수 있게 만들었습니다.

`FEAT: parseHttpBlock method and test functions.`
- http블록 파싱하는 함수를 만들었습니다. 

`REFACTOR: set config variables method`
- http, server, location 아래로 내려가면서 가지고 있는 설정을 상속해주는 함수를 만들었습니다.

`TEST: config file's inherit flow`
- 테스트 파일과 함수를 만들었습니다. 함수는 `ServerGenerator`에 만들었습니다. 후에 `isValid` 함수를 구현할 때 사용하기 위해 남겨놨습니다.