### PR TITLE
Feat/utils get line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-MAIN_FILES = ServerGenerator_test ServerManager ServerGenerator Server utils
+MAIN_FILES = getLine_test utils
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-MAIN_FILES = getLine_test utils
+MAIN_FILES = substr_test utils
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -21,6 +21,7 @@ namespace ft
     unsigned short hToNS(unsigned short hostshort);
     unsigned long nToHL(unsigned long hostlong);
     unsigned short nToHS(unsigned short hostshort);
+    std::string getLine(std::string &lines, std::string delim);
 }
 
 #endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -21,7 +21,7 @@ namespace ft
     unsigned short hToNS(unsigned short hostshort);
     unsigned long nToHL(unsigned long hostlong);
     unsigned short nToHS(unsigned short hostshort);
-    std::string getLine(std::string &lines, const std::string &delim);
+    bool substr(std::string &line, std::string &lines, const std::string &delim);
 }
 
 #endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -21,7 +21,7 @@ namespace ft
     unsigned short hToNS(unsigned short hostshort);
     unsigned long nToHL(unsigned long hostlong);
     unsigned short nToHS(unsigned short hostshort);
-    std::string getLine(std::string &lines, std::string delim);
+    std::string getLine(std::string &lines, const std::string &delim);
 }
 
 #endif

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -108,10 +108,9 @@ unsigned short nToHS(unsigned short hostshort)
            );
 }
 
-std::string getLine(std::string &lines, const std::string &delim)
+bool substr(std::string &line, std::string &lines, const std::string &delim)
 {
     size_t index;
-    std::string line;
 
     if ((index = lines.find(delim)) != std::string::npos)
     {
@@ -119,8 +118,12 @@ std::string getLine(std::string &lines, const std::string &delim)
         lines = lines.substr(index + delim.size());
     }
     else
-        return (lines);
-    return (line);
+    {
+        line = lines;
+        lines = "";
+        return (false);
+    }
+    return (true);
 }
 
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -108,7 +108,7 @@ unsigned short nToHS(unsigned short hostshort)
            );
 }
 
-std::string getLine(std::string &lines, std::string delim)
+std::string getLine(std::string &lines, const std::string &delim)
 {
     size_t index;
     std::string line;
@@ -119,10 +119,7 @@ std::string getLine(std::string &lines, std::string delim)
         lines = lines.substr(index + delim.size());
     }
     else
-    {
-        line = lines;
-        lines = lines.substr(lines.size());
-    }
+        return (lines);
     return (line);
 }
 

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -108,4 +108,22 @@ unsigned short nToHS(unsigned short hostshort)
            );
 }
 
+std::string getLine(std::string &lines, std::string delim)
+{
+    size_t index;
+    std::string line;
+
+    if ((index = lines.find(delim)) != std::string::npos)
+    {
+        line = lines.substr(0, index);
+        lines = lines.substr(index + delim.size());
+    }
+    else
+    {
+        line = lines;
+        lines = lines.substr(lines.size());
+    }
+    return (line);
+}
+
 }

--- a/tests/getLine_test.cpp
+++ b/tests/getLine_test.cpp
@@ -1,0 +1,29 @@
+#include "utils.hpp"
+#include <iostream>
+
+int main()
+{
+    std::string lines = "HTTP/1.1 200 OK\r\nServer: nginx/1.2.1\r\nContent-Type: text/html\r\nContent-Length: 8\r\nConnection: keep-alive\r\n\r\n<html />";
+    std::string line;
+
+    std::cout << "=========== Origin lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== first line ===========" << std::endl;
+    line = ft::getLine(lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== first getline after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+    
+    std::cout << "=========== second line ===========" << std::endl;
+    line = ft::getLine(lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== second getline after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== third line ===========" << std::endl;
+    line = ft::getLine(lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== third getline after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+}

--- a/tests/substr_test.cpp
+++ b/tests/substr_test.cpp
@@ -1,0 +1,59 @@
+#include "utils.hpp"
+#include <iostream>
+
+int main()
+{
+    std::string lines = "HTTP/1.1 200 OK\r\nServer: nginx/1.2.1\r\nContent-Type: text/html\r\nContent-Length: 8\r\nConnection: keep-alive\r\n\r\n<html />";
+    std::string line;
+
+    std::cout << "=========== Origin lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== 1 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 1 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+    
+    std::cout << "=========== 2 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 2 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== 3 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 3 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== 4 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 4 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== 5 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 5 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== 6 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 6 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== 7 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 7 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+
+    std::cout << "=========== 8 line ===========" << std::endl;
+    ft::substr(line, lines, "\r\n");
+    std::cout << line << std::endl;
+    std::cout << "=========== 8 substr after lines ===========" << std::endl;
+    std::cout << lines << std::endl << std::endl;
+}


### PR DESCRIPTION
getLine 함수 추가했습니다.

Prototype: `std::string getLine(std::string &lines, std::string delim);`

역할: delimeter 로 구분된 앞부분을 return 하고 인자로 들어온 lines에서 뒷부분을 delimeter 이후로 이동시킵니다.

Using Example
```C
    std::string lines = "HTTP/1.1 200 OK\r\nServer: nginx/1.2.1\r\nContent-Type: text/html\r\nContent-Length: 8\r\nConnection: keep-alive\r\n\r\n<html />";
    std::string line;

    line = ft::getLine(lines, "\r\n");
```

테스트 코드 추가했습니다.