### PR TITLE
Feat/run servers and server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-MAIN_FILES = runServers_test ServerManager ServerGenerator Server utils
+MAIN_FILES = runServers_test ServerManager ServerGenerator Server utils Request Response
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -20,13 +20,13 @@ private:
     std::string _status_code;
 
 private:
-    Request(const Request& other);
-    /* Overload */
+    /* Canonical but not implements */
     Request& operator=(const Request& rhs);
 
 public:
     /* Constructor */
     Request();
+    Request(const Request& other);
 
     /* Destructor */
     virtual ~Request();

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -19,5 +19,6 @@ public:
 /* Setter */
 /* Exception */
 /* Util */
-#endif
 };
+
+#endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -8,6 +8,9 @@
 # include <sys/types.h>
 # include <sys/time.h>
 # include <netinet/in.h>
+# include <algorithm>
+# include <vector>
+# include <fcntl.h>
 # include "types.hpp"
 # include "Request.hpp"
 # include "Response.hpp"
@@ -57,10 +60,11 @@ public:
 
     /* Server function */
     void init();
-    void run(ServerManager *server_manager);
+    void run(ServerManager *server_manager, int fd);
     Request receiveRequest(int fd);
     void makeResponse(Request& request, int fd);
     bool sendResponse(int fd);
+    bool isServerClient(int fd);
 };
 
 #endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -10,8 +10,10 @@
 # include <netinet/in.h>
 # include "types.hpp"
 # include "Request.hpp"
+# include "Response.hpp"
 
 class ServerManager;
+class Request;
 
 class Server
 {
@@ -22,17 +24,19 @@ private:
 
 private:
     std::map<std::string, std::string> _server_config;
+    // int _fd; 
     int _server_socket;
     std::vector<int> _client_sockets;
     std::string _server_name;
     std::string _host;
     std::string _port;
     int _status_code;
-    int _request_uri_limit_size;	
+    int _request_uri_limit_size;
     int _request_header_limit_size;
-    int _limit_client_body_size; 
+    int _limit_client_body_size;
     std::string _default_error_page;
     struct sockaddr_in _server_address;
+    std::vector<Response> _response;
 
 public:
     /* Constructor */
@@ -54,7 +58,7 @@ public:
     /* Server function */
     void init();
     void run(ServerManager *server_manager);
-    Request receiveRequest();
+    Request receiveRequest(int fd);
     void makeResponse(Request& request, int fd);
     bool sendResponse(int fd);
 };

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -15,6 +15,8 @@
 # include "Request.hpp"
 # include "Response.hpp"
 
+const int BUFFER_SIZE = 65536;
+
 class ServerManager;
 class Request;
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -15,7 +15,7 @@
 # include "Request.hpp"
 # include "Response.hpp"
 
-const int BUFFER_SIZE = 65536;
+const int BUFFER_SIZE = 1;
 
 class ServerManager;
 class Request;
@@ -66,7 +66,7 @@ public:
     Request receiveRequest(int fd);
     void makeResponse(Request& request, int fd);
     bool sendResponse(int fd);
-    bool isServerClient(int fd);
+    bool isClientOfServer(int fd);
 };
 
 #endif

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -14,7 +14,6 @@
 # include <iostream>
 # include <string>
 # include "types.hpp"
-# include "utils.hpp"
 # include "ServerGenerator.hpp"
 
 class Server;
@@ -51,10 +50,12 @@ public:
     const char *getConfigFilePath() const;
     int getFdMax() const;
     /* Setter */
+    void setFdMax(int fd);
     /* Exception */
     /* Util */
     bool fdIsSet(int fd, int type);
     void fdClr(int fd, int type);
+    void fdSet(int fd, int type);
 
     /* Manage Server functions */
     void initServers();

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -199,7 +199,6 @@ bool Request::parseRequest(std::string& req_message)
     }
     else
         parseRequestBodies(line);
-
     return (true);
 }
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -9,7 +9,15 @@
 /*============================================================================*/
 
 Request::Request()
-: _request_method(""), _request_uri(""), _request_version(""), _request_protocol(""), _request_bodies(""), _request_transfer_type(""), _status_code("") {}
+: _request_method(""), _request_uri(""), _request_version(""),
+ _request_protocol(""),
+_request_bodies(""), _request_transfer_type(""), _status_code("") {}
+
+Request::Request(const Request& other)
+: _request_method(other._request_method), _request_uri(other._request_uri), 
+_request_version(other._request_version), _request_headers(other._request_headers),
+_request_protocol(other._request_protocol), _request_bodies(other._request_bodies), 
+_request_transfer_type(other._request_transfer_type), _status_code(other._status_code) {}
 
 /*============================================================================*/
 /******************************  Destructor  **********************************/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -10,6 +10,7 @@
 
 Response::Response(const Response& object)
 {
+    static_cast<void>(object);
 }
 
 /*============================================================================*/
@@ -24,8 +25,9 @@ Response::~Response()
 /*******************************  Overload  ***********************************/
 /*============================================================================*/
 
-Response& Response::operator=(const Response& object)
+Response& Response::operator=(const Response& other)
 {
+    (void)other;
     return (*this);
 }
 /*============================================================================*/

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -189,9 +189,11 @@ Server::run(ServerManager *server_manager, int fd)
     {
         if (server_manager->fdIsSet(fd, WRITE_FDSET))
         {
+            // TODO: sendResponse error handling
             if (!(sendResponse(fd)))
                 std::cerr<<"Error: sendResponse"<<std::endl;
             server_manager->fdClr(fd, WRITE_FDSET);
+            //TODO: check chunked response before close(fd);
             close(fd);
             _client_sockets.erase(std::find(_client_sockets.begin(),
                         _client_sockets.end(), fd));

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -114,12 +114,16 @@ Server::receiveRequest(int fd)
     std::string req_message;
     char buf[BUFFER_SIZE + 1];
 
-    bytes = 0;
+    bytes = -42;
     memset(reinterpret_cast<void *>(buf), 0, BUFFER_SIZE + 1);
 
     while ((len = recv(fd, buf, BUFFER_SIZE, MSG_PEEK)) > 0)
     {
-        bytes = read(fd, buf, len);
+        if ((bytes = read(fd, buf, len)) < 0)
+        {
+            req.setStatusCode("400");
+            return (req);
+        }
         buf[bytes] = 0;
         req_message += buf;
     }
@@ -127,14 +131,8 @@ Server::receiveRequest(int fd)
     //TODO 우아한 종료 되었을 때 체크하기.
     // if (len == 0)
 
-    //TODO valid 체크 반영하기
     if (bytes >= 0)
         req.parseRequest(req_message);
-    else if (bytes < 0)
-    {
-        req.setStatusCode("400");
-        return (req);
-    }
     return (req);
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -92,7 +92,6 @@ Server::init()
     int option = true;
     setsockopt(_server_socket, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(int));
 
-    //TODO: memset 구현하기
     memset(&this->_server_address, 0, sizeof(this->_server_address));
     this->_server_address.sin_family = AF_INET;
     this->_server_address.sin_addr.s_addr = ft::hToNL(INADDR_ANY);
@@ -111,36 +110,27 @@ Server::receiveRequest(int fd)
 {
     Request req;
     int bytes;
+    int len;
     std::string req_message;
-    char buf[1024];
+    char buf[BUFFER_SIZE + 1];
 
     bytes = 0;
-    memset(reinterpret_cast<void *>(buf), 0, 1024);
-    while ((bytes = read(fd, buf, 1024)) > 0)
+    memset(reinterpret_cast<void *>(buf), 0, BUFFER_SIZE + 1);
+
+    while ((len = recv(fd, buf, BUFFER_SIZE, MSG_PEEK)) > 0)
     {
+        bytes = read(fd, buf, len);
         buf[bytes] = 0;
         req_message += buf;
     }
-    std::cout << "=========req message========\n" << req_message << std::endl;
-    req.parseRequest(req_message);
-    // if (bytes == 0) //TODO valid 체크 반영하기
-    //     req.parseRequest(req_message);
-    // else if (bytes < 0)
-    // {
-    //     std::cout << "in error" << std::endl;
-    //     req.setStatusCode("400");
-    //     return (req);
-    // }
-    // std::map<std::string, std::string> getRequestHeaders();
-    
-    std::cout << "======== Headers ========= " << std::endl;
-    std::map<std::string, std::string> headers = req.getRequestHeaders();
-    for (auto& s : headers)
-        std::cout << "key: " << s.first << "value: " << s.second << std::endl;
-    std::cout << "\n======= bodies ========" << std::endl;
-    std::cout << req.getRequestBodies() << std::endl;
-    std::cout << "\n======= uri ======== " << std::endl;
-    std::cout <<  req.getRequestUri()<< std::endl;
+    //TODO valid 체크 반영하기
+    if (bytes >= 0)
+        req.parseRequest(req_message);
+    else if (bytes < 0)
+    {
+        req.setStatusCode("400");
+        return (req);
+    }
     return (req);
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -172,13 +172,18 @@ Server::run(ServerManager *server_manager, int fd)
     if (fd == this->getServerSocket())
     {
         client_len = sizeof(client_address);
-        if ((client_socket = accept(this->getServerSocket(), reinterpret_cast<struct sockaddr *>(&client_address), reinterpret_cast<socklen_t *>(&client_len))) == -1)
-            std::cerr<<"accept error"<<std::endl;
-        this->_client_sockets.push_back(client_socket);
-        if (client_socket > server_manager->getFdMax())
-            server_manager->setFdMax(client_socket);
-        server_manager->fdSet(client_socket, READ_FDSET);
-        fcntl(client_socket, F_SETFL, O_NONBLOCK);
+        if ((client_socket = accept(this->getServerSocket(),
+            reinterpret_cast<struct sockaddr *>(&client_address),
+            reinterpret_cast<socklen_t *>(&client_len))) != -1)
+        {
+            this->_client_sockets.push_back(client_socket);
+            if (client_socket > server_manager->getFdMax())
+                server_manager->setFdMax(client_socket);
+            server_manager->fdSet(client_socket, READ_FDSET);
+            fcntl(client_socket, F_SETFL, O_NONBLOCK);
+        }
+        else
+            std::cerr<<"Accept error"<<std::endl;
     }
     else
     {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -92,7 +92,7 @@ Server::init()
 
     if ((this->_server_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
         throw "Socket Error";
-
+    std::cout<<"server socket fd: " << this->_server_socket <<std::endl;
     int option = true;
     setsockopt(_server_socket, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(int));
 
@@ -102,7 +102,8 @@ Server::init()
     this->_server_address.sin_addr.s_addr = ft::hToNL(INADDR_ANY);
     this->_server_address.sin_port = ft::hToNS(stoi(this->_port));
 
-    if (bind(this->_server_socket, reinterpret_cast<struct sockaddr *>(&this->_server_address), static_cast<socklen_t>(sizeof(this->_server_address))))
+    if (bind(this->_server_socket, reinterpret_cast<struct sockaddr *>(&this->_server_address),
+        static_cast<socklen_t>(sizeof(this->_server_address))))
         throw "Bind error";
 
     if (listen(this->_server_socket, 128) == -1)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -115,15 +115,32 @@ Server::receiveRequest(int fd)
     char buf[1024];
 
     bytes = 0;
+    memset(reinterpret_cast<void *>(buf), 0, 1024);
     while ((bytes = read(fd, buf, 1024)) > 0)
-        req_message += buf;
-    if (bytes == 0) //TODO valid 체크 반영하기
-        req.parseRequest(req_message);
-    else if (bytes < 0)
     {
-        req.setStatusCode("400");
-        return (req);
+        buf[bytes] = 0;
+        req_message += buf;
     }
+    std::cout << "=========req message========\n" << req_message << std::endl;
+    req.parseRequest(req_message);
+    // if (bytes == 0) //TODO valid 체크 반영하기
+    //     req.parseRequest(req_message);
+    // else if (bytes < 0)
+    // {
+    //     std::cout << "in error" << std::endl;
+    //     req.setStatusCode("400");
+    //     return (req);
+    // }
+    // std::map<std::string, std::string> getRequestHeaders();
+    
+    std::cout << "======== Headers ========= " << std::endl;
+    std::map<std::string, std::string> headers = req.getRequestHeaders();
+    for (auto& s : headers)
+        std::cout << "key: " << s.first << "value: " << s.second << std::endl;
+    std::cout << "\n======= bodies ========" << std::endl;
+    std::cout << req.getRequestBodies() << std::endl;
+    std::cout << "\n======= uri ======== " << std::endl;
+    std::cout <<  req.getRequestUri()<< std::endl;
     return (req);
 }
 
@@ -185,7 +202,7 @@ Server::run(ServerManager *server_manager, int fd)
         }
         else if (server_manager->fdIsSet(fd, READ_FDSET))
         {
-            Request request = this->receiveRequest(fd);
+            Request request(this->receiveRequest(fd));
             this->makeResponse(request, fd);
             server_manager->fdSet(fd, WRITE_FDSET);
             server_manager->fdClr(fd, READ_FDSET);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -75,8 +75,9 @@ int Server::getServerSocket()
 /*============================================================================*/
 /*********************************  Util  *************************************/ 
 /*============================================================================*/
- 
-void Server::init()
+
+void
+Server::init()
 {
 
     for (auto& conf: this->_server_config)
@@ -97,7 +98,7 @@ void Server::init()
 
     //TODO: memset 구현하기
     memset(&this->_server_address, 0, sizeof(this->_server_address));
-    this->_server_address.sin_family = AF_INET;;
+    this->_server_address.sin_family = AF_INET;
     this->_server_address.sin_addr.s_addr = ft::hToNL(INADDR_ANY);
     this->_server_address.sin_port = ft::hToNS(stoi(this->_port));
 
@@ -108,12 +109,50 @@ void Server::init()
         throw "Listen error";
 }
 
-void Server::run(ServerManager *server_manager)
+Request
+Server::receiveRequest(int fd)
+{
+    Request req;
+    int bytes;
+    std::string req_message;
+    char buf[1024];
+
+    bytes = 0;
+    while ((bytes = read(fd, buf, 1024)) > 0)
+        req_message += buf;
+    if (bytes == 0) //TODO valid 체크 반영하기
+        req.parseRequest(req_message);
+    else if (bytes < 0)
+    {
+        req.setStatusCode("400");
+        return (req);
+    }
+    return (req);
+}
+
+void
+Server::makeResponse(Request& request, int fd)
+{
+    (void)fd;
+    (void)request;
+    std::string res = "OPTION / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nUser-Agent: Mozilla/5.0 (Macintosh;) Firefox/51.0\r\nAccept-Charsets: text/html\r\nAccept-Language: en-US\r\nContent-Type: multipart/form-data\r\nContent-Length: 345\r\n\r\nHelloWorld, everybody, buddy, whatsup\r\n";
+}
+
+bool
+Server::sendResponse(int fd)
+{
+    std::cout<<"in sendResponse fd: " << fd << std::endl;
+    return (true);
+}
+
+void
+Server::run(ServerManager *server_manager)
 {
     int client_len;
     struct sockaddr_in client_address;
     int client_socket;
 
+    // for (this->_fd = 0; this->_fd < server_manager->getFdMax(); this->_fd++)
     for (int fd = 0; fd < server_manager->getFdMax(); fd++)
     {
         if (server_manager->fdIsSet(fd, ALL_FDSET))
@@ -122,7 +161,7 @@ void Server::run(ServerManager *server_manager)
             {
                 client_len = sizeof(client_address);
                 //TODO: client_address 지역변수로 써도되는지 체크
-                if ((client_socket = accept(this->getServerSocket(), reinterpret_cast<struct socketaddr *>(&client_address), reinterpret_cast<socklen_t *>(&client_len))) == -1)
+                if ((client_socket = accept(this->getServerSocket(), reinterpret_cast<struct sockaddr *>(&client_address), reinterpret_cast<socklen_t *>(&client_len))) == -1)
                     std::cerr<<"accept error"<<std::endl;
                 if (server_manager->getFdMax() < client_socket)
                     server_manager->setFdMax(client_socket);
@@ -136,11 +175,12 @@ void Server::run(ServerManager *server_manager)
                         std::cerr<<"Error: sendResponse"<<std::endl;
                     }
                     server_manager->fdClr(fd, WRITE_FDSET);
-                    // cont
+                    // continue
                 }
                 else if (server_manager->fdIsSet(fd, READ_FDSET))
                 {
-                    this->makeResponse(this->receiveRequest(), fd);
+                    Request request = this->receiveRequest(fd);
+                    this->makeResponse(request, fd);
                     server_manager->fdSet(fd, WRITE_FDSET);
                     server_manager->fdClr(fd, READ_FDSET);
                 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -123,6 +123,10 @@ Server::receiveRequest(int fd)
         buf[bytes] = 0;
         req_message += buf;
     }
+
+    //TODO 우아한 종료 되었을 때 체크하기.
+    // if (len == 0)
+
     //TODO valid 체크 반영하기
     if (bytes >= 0)
         req.parseRequest(req_message);
@@ -151,7 +155,7 @@ Server::sendResponse(int fd)
 }
 
 bool
-Server::isServerClient(int fd)
+Server::isClientOfServer(int fd)
 {
     return ((std::find(this->_client_sockets.begin(),
             this->_client_sockets.end(), fd)

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -90,6 +90,12 @@ ServerManager::fdSet(int fd, int type)
         ft::fdSet(fd, &this->_writefds);
     else if (type == EXCEPT_FDSET)
         ft::fdSet(fd, &this->_exceptfds);
+    else
+    {
+        ft::fdSet(fd, &this->_readfds);
+        ft::fdSet(fd, &this->_writefds);
+        ft::fdSet(fd, &this->_exceptfds);
+    }
 }
 
 bool
@@ -140,6 +146,12 @@ ServerManager::runServers()
 
     timeout.tv_sec = 5;
     timeout.tv_usec = 5;
+    for (Server *server : this->_servers)
+    {
+        int server_socket = server->getServerSocket();
+        this->fdSet(server_socket, ALL_FDSET);
+        this->setFdMax(server_socket);
+    }
 
     //TODO: siganl 입력시 반복종료 구현
     while (true)
@@ -154,11 +166,15 @@ ServerManager::runServers()
         }
         else if (selected_fds == 0)
         {
-            std::cout << " time out " << std::endl;
+            std::cout<<"Time Out"<<std::endl;
             continue ;
         }
+        std::cout<<"start server run"<<std::endl;
         for (Server *server : this->_servers)
+        {
+            std::cout<<"run server"<<std::endl;
             server->run(this);
+        }
     }
     return (true);
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -179,7 +179,7 @@ ServerManager::runServers()
                     for (Server *server : this->_servers)
                     {
                         if (fd == server->getServerSocket() ||
-                            server->isServerClient(fd))
+                            server->isClientOfServer(fd))
                             server->run(this, fd);
                     }
                 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -135,7 +135,7 @@ void
 ServerManager::initServers()
 {
     ServerGenerator server_generator(this);
-    server_generator.generateServers(this->_servers); // config파일을 순회하며 Server객체 생성 _servers.push_b
+    server_generator.generateServers(this->_servers);
 }
 
 bool
@@ -158,7 +158,9 @@ ServerManager::runServers()
         this->_copy_readfds = this->_readfds;
         this->_copy_writefds = this->_writefds;
         this->_copy_exceptfds = this->_exceptfds;
-        if ((selected_fds = select(this->getFdMax() + 1, &this->_copy_readfds, &this->_copy_writefds, &this->_copy_exceptfds, &timeout)) == -1)
+        if ((selected_fds = select(this->getFdMax() + 1,
+             &this->_copy_readfds, &this->_copy_writefds,
+             &this->_copy_exceptfds, &timeout)) == -1)
         {
             std::cerr<<"Error : select"<<std::endl;
             return (false);
@@ -176,7 +178,8 @@ ServerManager::runServers()
                 {
                     for (Server *server : this->_servers)
                     {
-                        if (fd == server->getServerSocket() || server->isServerClient(fd))
+                        if (fd == server->getServerSocket() ||
+                            server->isServerClient(fd))
                             server->run(this, fd);
                     }
                 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -1,5 +1,6 @@
 #include "ServerManager.hpp"
 #include "Server.hpp"
+#include "utils.hpp"
 
 /*============================================================================*/
 /****************************  Static variables  ******************************/
@@ -66,6 +67,12 @@ ServerManager::getFdMax() const
 /********************************  Setter  ************************************/
 /*============================================================================*/
 
+void
+ServerManager::setFdMax(int fd)
+{
+    this->_fd_max = fd;
+}
+
 /*============================================================================*/
 /******************************  Exception  ***********************************/
 /*============================================================================*/
@@ -73,6 +80,17 @@ ServerManager::getFdMax() const
 /*============================================================================*/
 /*********************************  Util  *************************************/
 /*============================================================================*/
+
+void
+ServerManager::fdSet(int fd, int type)
+{
+    if (type == READ_FDSET)
+        ft::fdSet(fd, &this->_readfds);
+    else if (type == WRITE_FDSET)
+        ft::fdSet(fd, &this->_writefds);
+    else if (type == EXCEPT_FDSET)
+        ft::fdSet(fd, &this->_exceptfds);
+}
 
 bool
 ServerManager::fdIsSet(int fd, int type)
@@ -135,13 +153,19 @@ ServerManager::runServers()
             return (false);
         }
         else if (selected_fds == 0)
+        {
+            std::cout << " time out " << std::endl;
             continue ;
-        std::cout << "in while" << std::endl;
+        }
         for (Server *server : this->_servers)
             server->run(this);
     }
     return (true);
 }
+
+
+
+
 
 
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -119,11 +119,11 @@ void
 ServerManager::fdClr(int fd, int type)
 {
     if (type == READ_FDSET)
-        ft::fdClr(fd, &this->_copy_readfds);
+        ft::fdClr(fd, &this->_readfds);
     else if (type == WRITE_FDSET)
-        ft::fdClr(fd, &this->_copy_writefds);
+        ft::fdClr(fd, &this->_writefds);
     else if (type == EXCEPT_FDSET)
-        ft::fdClr(fd, &this->_copy_exceptfds);
+        ft::fdClr(fd, &this->_exceptfds);
 }
 
 /*============================================================================*/
@@ -152,7 +152,6 @@ ServerManager::runServers()
         this->fdSet(server_socket, ALL_FDSET);
         this->setFdMax(server_socket);
     }
-
     //TODO: siganl 입력시 반복종료 구현
     while (true)
     {
@@ -169,59 +168,23 @@ ServerManager::runServers()
             std::cout<<"Time Out"<<std::endl;
             continue ;
         }
-        std::cout<<"start server run"<<std::endl;
-        for (Server *server : this->_servers)
+        else
         {
-            std::cout<<"run server"<<std::endl;
-            server->run(this);
+            for (int fd = 0; fd < this->getFdMax() + 1; fd++)
+            {
+                if (this->fdIsSet(fd, ALL_FDSET))
+                {
+                    for (Server *server : this->_servers)
+                    {
+                        if (fd == server->getServerSocket() || server->isServerClient(fd))
+                            server->run(this, fd);
+                    }
+                }
+            }
         }
     }
     return (true);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -2,21 +2,20 @@ http {
     include mime.types;
     root /test/folder;
     server {
-        server_name first_server;
-        root html;
-        listen 8081;
-        location / {
+        server_name second_server;
+        listen       8080;
+        location /please {
             index  index.html index.htm;
-            limit_except GET POST
         }
-        location /abc {
-            root  /user/sanam;
-            index  hahahoho.html;
+        location /only-put {
+            root  /user/iwoo;
+            index  html;
+            limit_except PUT
         }
     }
     server {
         server_name second_server;
-        listen       8080;
+        listen       8081;
         location /please {
             index  index.html index.htm;
         }


### PR DESCRIPTION
일단 select 부분에서의 구조를 많이 수정했습니다.

기존에는 server의 run메써드에서 모든 fd를 검사했었는데

수정 이후에는 serverManager에서 반복을 수행하고 만약 해당하는 server 의 fd가 변경되었다면, server의 run메써드를 호출하게 합니다.

구조를 바꾸는 과정에서
ServerManager의 `fdClr` 메써드에 문제가 있음을 발견하고 수정했습니다.
또한 Server의 클라이언트 fd인지를 검사하는 메써드 `isServerClient`를 추가했습니다.