### PR TITLE
Feat/request parse chunked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-MAIN_FILES = runServers_test ServerManager ServerGenerator Server utils Request Response
+# MAIN_FILES = runServers_test ServerManager ServerGenerator Server utils Request Response
+MAIN_FILES = utils Request Chunked_test
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -63,7 +63,7 @@ public:
     bool parseRequest(std::string& req_message);
     bool parseRequestLine(std::string& req_message);
     bool parseRequestHeaders(std::string& req_message);
-    void parseRequestBodies(std::string& req_message);
+    bool parseRequestBodies(std::string& req_message);
 
     bool parseChunkedBody(std::string &req_message);
 

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -65,6 +65,8 @@ public:
     bool parseRequestHeaders(std::string& req_message);
     void parseRequestBodies(std::string& req_message);
 
+    bool parseChunkedBody(std::string &req_message);
+
 };
 
 #endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -25,7 +25,7 @@ namespace ft
     bool substr(std::string &line, std::string &lines, const std::string &delim);
     void* memset(void* b, int c, size_t len);
 
-    int stoiHex(std::string str);
+    int stoiHex(const std::string& str);
 }
 
 #endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -24,6 +24,8 @@ namespace ft
 
     bool substr(std::string &line, std::string &lines, const std::string &delim);
     void* memset(void* b, int c, size_t len);
+
+    int stoiHex(std::string str);
 }
 
 #endif

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -190,30 +190,6 @@ bool Request::parseRequest(std::string& req_message)
     return (true);
 }
 
-bool
-Request::parseChunkedBody(std::string &req_message)
-{
-    int line_len;
-    std::string line;
-
-    while (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
-    {
-        line_len = ft::stoiHex(line);
-        if (line_len == 0)
-            return (true);
-        else if (line_len != -1)
-        {
-            if (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
-                this->_request_bodies += line.substr(0, line_len) + "\r\n";
-            else
-                return (false);
-        }
-        else
-            return (false);
-    }
-    return (true);
-}
-
 bool Request::parseRequestLine(std::string& req_message)
 {
     std::vector<std::string> request_line = ft::split(req_message, " ");
@@ -248,6 +224,30 @@ bool Request::parseRequestHeaders(std::string& req_message)
     headers[key] = value;
     this->setRequestHeaders(key, value);
 
+    return (true);
+}
+
+bool
+Request::parseChunkedBody(std::string &req_message)
+{
+    int line_len;
+    std::string line;
+
+    while (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
+    {
+        line_len = ft::stoiHex(line);
+        if (line_len == 0)
+            return (true);
+        else if (line_len != -1)
+        {
+            if (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
+                this->_request_bodies += line.substr(0, line_len) + "\r\n";
+            else
+                return (false);
+        }
+        else
+            return (false);
+    }
     return (true);
 }
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -29,17 +29,20 @@ Request::~Request() {}
 /********************************  Getter  ************************************/
 /*============================================================================*/
 
-std::string Request::getRequestMethod()
+std::string
+Request::getRequestMethod()
 {
     return (this->_request_method);
 }
 
-std::string Request::getRequestUri()
+std::string
+Request::getRequestUri()
 {
     return (this->_request_uri);
 }
 
-std::string Request::getRequestVersion()
+std::string
+Request::getRequestVersion()
 {
     return (this->_request_version);
 }
@@ -49,22 +52,26 @@ std::map<std::string, std::string> Request::getRequestHeaders()
     return (this->_request_headers);
 }
 
-std::string Request::getRequestProtocol()
+std::string
+Request::getRequestProtocol()
 {
     return (this->_request_protocol);
 }
 
-std::string Request::getRequestBodies()
+std::string
+Request::getRequestBodies()
 {
     return (this->_request_bodies);
 }
 
-std::string Request::getRequestTransferType()
+std::string
+Request::getRequestTransferType()
 {
     return (this->_request_transfer_type);
 }
 
-std::string Request::getStatusCode()
+std::string
+Request::getStatusCode()
 {
     return (this->_status_code);
 }
@@ -73,49 +80,58 @@ std::string Request::getStatusCode()
 /********************************  Setter  ************************************/
 /*============================================================================*/
 
-void Request::setRequestMethod(const std::string& method)
+void
+Request::setRequestMethod(const std::string& method)
 {
     this->_request_method = method;
 }
 
-void Request::setRequestUri(const std::string& uri)
+void
+Request::setRequestUri(const std::string& uri)
 {
     this->_request_uri = uri;
 }
 
-void Request::setRequestVersion(const std::string& version)
+void
+Request::setRequestVersion(const std::string& version)
 {
     this->_request_version = version;
 }
 
 //TODO: insert를 하기 때문에 중복된 헤더가 키로 들어올 때 무시된다. 만약에 처음 삽입된 밸류에 문제가 있으면 그것이 그냥 작동하는 것..
-void Request::setRequestHeaders(std::map<std::string, std::string>& headers)
+void
+Request::setRequestHeaders(std::map<std::string, std::string>& headers)
 {
     for (auto& h : headers)
         this->_request_headers.insert(make_pair(h.first, h.second));
 }
 
-void Request::setRequestHeaders(const std::string& key, const std::string& value)
+void
+Request::setRequestHeaders(const std::string& key, const std::string& value)
 {
     this->_request_headers[key] = value;
 }
 
-void Request::setRequestProtocol(const std::string& protocol)
+void
+Request::setRequestProtocol(const std::string& protocol)
 {
     this->_request_protocol = protocol;
 }
 
-void Request::setRequestBodies(const std::string& req_message)
+void
+Request::setRequestBodies(const std::string& req_message)
 {
     this->_request_bodies = req_message;
 }
 
-void Request::setRequestTransferType(const std::string& transfer_type)
+void
+Request::setRequestTransferType(const std::string& transfer_type)
 {
     this->_request_transfer_type = transfer_type;
 }
 
-void Request::setStatusCode(const std::string& status_code)
+void
+Request::setStatusCode(const std::string& status_code)
 {
     this->_status_code = status_code;
 }
@@ -154,7 +170,8 @@ void Request::setStatusCode(const std::string& status_code)
 //NOTE: message body가 있다면 octets의 양이 message_body_length와 같을 때까지 읽거나 커넥션을 닫는다.
 //NOTE: HTTP 메세지를 octet sequence로 인코딩해야 하며 그것은 US-ASCII로 이루어진다.
 
-bool Request::parseRequest(std::string& req_message)
+bool
+Request::parseRequest(std::string& req_message)
 {
     std::string line;
 
@@ -185,12 +202,11 @@ bool Request::parseRequest(std::string& req_message)
 
     if (ft::substr(line, req_message, "\r\n\r\n") == false)
         return (false);
-    else
-        parseRequestBodies(line);
-    return (true);
+    return (parseRequestBodies(line));
 }
 
-bool Request::parseRequestLine(std::string& req_message)
+bool
+Request::parseRequestLine(std::string& req_message)
 {
     std::vector<std::string> request_line = ft::split(req_message, " ");
 
@@ -200,7 +216,8 @@ bool Request::parseRequestLine(std::string& req_message)
     return (true);
 }
 
-bool Request::parseRequestHeaders(std::string& req_message)
+bool
+Request::parseRequestHeaders(std::string& req_message)
 {
     std::string key;
     std::string value;
@@ -233,6 +250,7 @@ Request::parseChunkedBody(std::string &req_message)
     int line_len;
     std::string line;
 
+    //TODO: 라인에서 \r\n을 찾지 못하면 true로 종료됨. 이후 valid check 시 상태코드 업데이트하게끔 수정요망.
     while (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
     {
         line_len = ft::stoiHex(line);
@@ -251,7 +269,9 @@ Request::parseChunkedBody(std::string &req_message)
     return (true);
 }
 
-void Request::parseRequestBodies(std::string& req_message)
+bool
+Request::parseRequestBodies(std::string& req_message)
 {
     this->setRequestBodies(req_message);
+    return (true);
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -136,4 +136,20 @@ void* memset(void* b, int c, size_t len)
     return (b);
 }
 
+int stoiHex(std::string str)
+{
+    int ret = 0;
+    std::string digit = "0123456789abcdef";
+
+    if (str.empty() || digit.find(str[0]) == std::string::npos)
+        return (-1);
+    while (!str.empty() && digit.find(str[0]) != std::string::npos)
+    {
+        ret *= 16;
+        ret += digit.find(str[0]);
+        str.erase(str.begin());
+    }
+    return (ret);
+}
+
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -136,18 +136,36 @@ void* memset(void* b, int c, size_t len)
     return (b);
 }
 
-int stoiHex(std::string str)
+// int stoiHex(std::string str)
+// {
+//     int ret = 0;
+//     std::string digit = "0123456789abcdef";
+
+//     if (str.empty() || digit.find(str[0]) == std::string::npos)
+//         return (-1);
+//     while (!str.empty() && digit.find(str[0]) != std::string::npos)
+//     {
+//         ret *= 16;
+//         ret += digit.find(str[0]);
+//         str.erase(str.begin());
+//     }
+//     return (ret);
+// }
+
+int stoiHex(const std::string& str)
 {
     int ret = 0;
-    std::string digit = "0123456789abcdef";
+    int i = 0;
+    size_t pos = 0;
+    const std::string digit = "0123456789abcdef";
 
-    if (str.empty() || digit.find(str[0]) == std::string::npos)
+    if (str.empty() || digit.find(str[i]) == std::string::npos)
         return (-1);
-    while (!str.empty() && digit.find(str[0]) != std::string::npos)
+    while ((pos = digit.find(str[i])) != std::string::npos)
     {
         ret *= 16;
-        ret += digit.find(str[0]);
-        str.erase(str.begin());
+        ret += pos;
+        i++;
     }
     return (ret);
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -136,22 +136,6 @@ void* memset(void* b, int c, size_t len)
     return (b);
 }
 
-// int stoiHex(std::string str)
-// {
-//     int ret = 0;
-//     std::string digit = "0123456789abcdef";
-
-//     if (str.empty() || digit.find(str[0]) == std::string::npos)
-//         return (-1);
-//     while (!str.empty() && digit.find(str[0]) != std::string::npos)
-//     {
-//         ret *= 16;
-//         ret += digit.find(str[0]);
-//         str.erase(str.begin());
-//     }
-//     return (ret);
-// }
-
 int stoiHex(const std::string& str)
 {
     int ret = 0;

--- a/tests/Chunked_test.cpp
+++ b/tests/Chunked_test.cpp
@@ -1,0 +1,23 @@
+#include "Request.hpp"
+#include "utils.hpp"
+#include <iostream>
+
+int main()
+{
+    std::string req = "OPTION / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcdef\r\na\r\n01234567890\r\n0";
+
+	Request test;
+	test.parseRequest(req);
+
+	std::cout << "============================= result =============================" << std::endl;
+    std::cout << test.getRequestMethod() << std::endl;
+    std::cout << test.getRequestUri() << std::endl;
+    std::cout << test.getRequestVersion() << std::endl;
+    for (auto& kv : test.getRequestHeaders())
+    {
+        std::cout << kv.first << std::endl;
+        std::cout << kv.second << std::endl;
+    }
+    std::cout << test.getRequestBodies() << std::endl;
+
+}

--- a/tests/stoi_hex_test.cpp
+++ b/tests/stoi_hex_test.cpp
@@ -1,0 +1,17 @@
+#include "utils.hpp"
+#include <iostream>
+
+int main()
+{
+	std::string test1 = "abc";
+	std::string test2 = "z123";
+	std::string test3 = "1a87";
+	std::string test4 = "0";
+	std::string test5 = "a";
+
+	std::cout << "Test1: " << ft::stoiHex(test1) << std::endl;
+	std::cout << "Test2: " << ft::stoiHex(test2) << std::endl;
+	std::cout << "Test3: " << ft::stoiHex(test3) << std::endl;
+	std::cout << "Test4: " << ft::stoiHex(test4) << std::endl;
+	std::cout << "Test5: " << ft::stoiHex(test5) << std::endl;
+}

--- a/tests/stoi_hex_test.cpp
+++ b/tests/stoi_hex_test.cpp
@@ -7,7 +7,7 @@ int main()
 	std::string test2 = "z123";
 	std::string test3 = "1a87";
 	std::string test4 = "0";
-	std::string test5 = "a";
+	std::string test5 = "az";
 
 	std::cout << "Test1: " << ft::stoiHex(test1) << std::endl;
 	std::cout << "Test2: " << ft::stoiHex(test2) << std::endl;


### PR DESCRIPTION
리퀘스트 헤더로 `Transfer-Encoding`의 밸류가 `chunked` 인 경우 파싱하는 메써드를 추가했습니다.

청크드 바디의 리퀘스트 바디는 `숫자\r\n데이터 .... \r\n0` 같은 형태를 띄고 있고 숫자는 16진수입니다.

따라서 16진수의 값을 10진수로 변환하는 `stoiHex`를 만들었습니다.
