### PR TITLE
Feat/response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # MAIN_FILES = main 
-# MAIN_FILES = runServers_test ServerManager ServerGenerator Server utils Request Response
-MAIN_FILES = utils Request Chunked_test
+MAIN_FILES = runServers_test ServerManager ServerGenerator Server utils Request Response
+# MAIN_FILES = utils Request Chunked_test
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -1,8 +1,8 @@
 #ifndef REQUEST_HPP
 # define REQUEST_HPP
 
-# include "Server.hpp"
 # include "utils.hpp"
+# include <map>
 
 //TODO: 테스트용
 # include <iostream>

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -19,14 +19,11 @@ private:
     std::string _request_transfer_type;
     std::string _status_code;
 
-private:
-    /* Canonical but not implements */
-    Request& operator=(const Request& rhs);
-
 public:
     /* Constructor */
     Request();
     Request(const Request& other);
+    Request& operator=(const Request& rhs);
 
     /* Destructor */
     virtual ~Request();
@@ -45,10 +42,7 @@ public:
     void setRequestMethod(const std::string& method);
     void setRequestUri(const std::string& uri);
     void setRequestVersion(const std::string& version);
-    void setRequestHeaders(std::map<std::string, std::string>& request_headers);
-    
     void setRequestHeaders(const std::string& key, const std::string& value);
-    
     void setRequestProtocol(const std::string& protocol);
     void setRequestBodies(const std::string& body);
     void setRequestTransferType(const std::string& transfer_type);
@@ -60,6 +54,7 @@ public:
 
     // void initMembers(std::string req_message);
 
+    /* parser */
     bool parseRequest(std::string& req_message);
     bool parseRequestLine(std::string& req_message);
     bool parseRequestHeaders(std::string& req_message);
@@ -67,6 +62,18 @@ public:
 
     bool parseChunkedBody(std::string &req_message);
 
+    /* valid check */
+    bool isValidRequestLine(std::vector<std::string>& request_line);
+    bool isValidRequestMethod(const std::string& method);
+    bool isValidRequestUri(const std::string& uri);
+    bool isValidRequestVersion(const std::string& version);
+
+    bool isValidRequestHeaders(std::string& key, std::string& value);
+    bool isValidRequestHeaderFields(std::string& key);
+    bool isValidSP(std::string& str);
+    bool isDuplicated(std::string& key);
+
+    bool isValidRequestBodies();
 };
 
 #endif

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -9,7 +9,6 @@ class Response
 {
 private:
     std::string _status_code;
-    std::string _status_description;
     std::map<std::string, std::string> _headers;
     std::string _transfer_type;
     std::string _clients;
@@ -29,21 +28,22 @@ public:
     Response& operator=(const Response& rhs);
     /* Getter */
     std::string getStatusCode() const;
-    // std::string getStatusDescription() const;
+    std::string getStatusMessage(const std::string& code);
     // std::string getHeaders() const;
     // std::string getTransferType() const;
     // std::string getClients() const;
     /* Setter */
     void setStatusCode(Request& request);
-    void setStatusCode(std::string& status_code);
-    void setStatusDescription();
+    void setStatusCode(const std::string& status_code);
     // void setMessageBody();
     /* Exception */
     /* Util */
 
     void init();
     void initStatusCodeTable();
-    void initAndUpdate(Request& request);
+    // std::string makeBody(Request& request);
+    // std::string makeHeaders(Request& request);
+    std::string makeStartLine();
 };
 
 #endif

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -1,24 +1,43 @@
 #ifndef RESPONSE_HPP
 # define RESPONSE_HPP
 
+# include "Request.hpp"
+
+class Server;
+
 class Response
 {
 private:
-    /* data */
+    std::string _status_code;
+    std::string _status_description;
+    std::string _headers;
+    std::string _transfer_type;
+    std::string _clients;
+    std::string _message_body;
+
 public:
     /* Constructor */
-    Response(/* args*/);
+    Response();
     Response(const Response& other);
+    Response(Request& request, Server* server); //TODO 인자를 const로.
 
     /* Destructor */
     virtual ~Response();
 
     /* Overload */
     Response& operator=(const Response& rhs);
-/* Getter */
-/* Setter */
-/* Exception */
-/* Util */
+    /* Getter */
+    std::string getStatusCode() const;
+    // std::string getStatusDescription() const;
+    // std::string getHeaders() const;
+    // std::string getTransferType() const;
+    // std::string getClients() const;
+    /* Setter */
+    void setStatusCode(Request& request);
+    void setStatusCode(std::string& status_code);
+    // void setMessageBody();
+    /* Exception */
+    /* Util */
 };
 
 #endif

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -43,7 +43,7 @@ public:
     void initStatusCodeTable();
     // std::string makeBody(Request& request);
     // std::string makeHeaders(Request& request);
-    std::string makeStartLine();
+    std::string makeStatusLine();
 };
 
 #endif

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -10,16 +10,17 @@ class Response
 private:
     std::string _status_code;
     std::string _status_description;
-    std::string _headers;
+    std::map<std::string, std::string> _headers;
     std::string _transfer_type;
     std::string _clients;
     std::string _message_body;
+    std::map<std::string, std::string> _status_code_table;
 
 public:
     /* Constructor */
     Response();
     Response(const Response& other);
-    Response(Request& request, Server* server); //TODO 인자를 const로.
+    // Response(Request& request, Server* server); //TODO 인자를 const로.
 
     /* Destructor */
     virtual ~Response();
@@ -35,9 +36,14 @@ public:
     /* Setter */
     void setStatusCode(Request& request);
     void setStatusCode(std::string& status_code);
+    void setStatusDescription();
     // void setMessageBody();
     /* Exception */
     /* Util */
+
+    void init();
+    void initStatusCodeTable();
+    void initAndUpdate(Request& request);
 };
 
 #endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -16,7 +16,7 @@
 # include "Request.hpp"
 # include "Response.hpp"
 
-const int BUFFER_SIZE = 1;
+const int BUFFER_SIZE = 9000;
 
 class ServerManager;
 class Request;
@@ -42,7 +42,7 @@ private:
     int _limit_client_body_size;
     std::string _default_error_page;
     struct sockaddr_in _server_address;
-    std::vector<Response> _response;
+    std::vector<Request> _requests;
 
 public:
     /* Constructor */
@@ -63,10 +63,10 @@ public:
 
     /* Server function */
     void init();
-    void run(ServerManager *server_manager, int fd);
-    Request receiveRequest(int fd);
-    void makeResponse(Request& request, int fd);
-    bool sendResponse(int fd);
+    void run(ServerManager* server_manager, int fd);
+    Request receiveRequest(ServerManager* server_manager, int fd);
+    std::string makeResponseMessage(Request& request);
+    bool sendResponse(std::string& response_meesage, int fd);
     bool isClientOfServer(int fd);
 };
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -43,10 +43,11 @@ private:
     std::string _default_error_page;
     struct sockaddr_in _server_address;
     std::vector<Request> _requests;
+    std::map<std::string, location_info> _location_config;
 
 public:
     /* Constructor */
-    Server(server_info& server_config, std::map<std::string, location_info> location_config);
+    Server(server_info& server_config, std::map<std::string, location_info>& location_config);
         /* Destructor */
     virtual ~Server();
 

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -38,7 +38,6 @@ private:
     std::string _port;
     int _fd;
     int _fd_max;
-    std::map<int, std::string> _status_code_msg;
 
 public:
     /* Constructor */

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -170,6 +170,7 @@ Request::parseRequest(std::string& req_message)
             return (false);
         }
     }
+
     if (ft::substr(line, req_message, "\r\n\r\n") == false)
     {
         this->setStatusCode("400");
@@ -189,14 +190,7 @@ Request::parseRequest(std::string& req_message)
         if (this->_request_headers["Transfer-Encoding"] == "chunked")
             return (parseChunkedBody(req_message));
     }
-
-    // if (ft::substr(line, req_message, "\r\n") == false)
-    // {
-    //     std::cout << "in if" << std::endl;
-    //     this->setStatusCode("400");
-    //     return (false);
-    // }
-    return (parseRequestBodies(line));
+    return (parseRequestBodies(req_message));
 }
 
 bool
@@ -288,12 +282,6 @@ Request::parseChunkedBody(std::string &req_message)
 bool
 Request::parseRequestBodies(std::string& req_message)
 {
-    for (auto& kv : this->getRequestHeaders())
-        std::cout << "headers key: " << kv.first << " " << kv.second << std::endl;
-    std::cout << "---------------------------" << std::endl;
-    std::cout << req_message << std::endl;
-    std::cout << "---------------------------" << std::endl;
-
     this->setRequestBodies(req_message);
     return (true);
 }

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -10,8 +10,8 @@
 
 Request::Request()
 : _request_method(""), _request_uri(""), _request_version(""),
- _request_protocol(""),
-_request_bodies(""), _request_transfer_type(""), _status_code("") {}
+ _request_protocol(""), _request_bodies(""), _request_transfer_type(""), 
+ _status_code("") {}
 
 Request::Request(const Request& other)
 : _request_method(other._request_method), _request_uri(other._request_uri), 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -8,9 +8,22 @@
 /******************************  Constructor  *********************************/
 /*============================================================================*/
 
-Response::Response(const Response& object)
+Response::Response()
+: _status_code(""), _status_description(""), _headers(""), _transfer_type(""),
+_clients(""), _message_body("") {}
+
+Response::Response(const Response& other)
+: _status_code(other._status_code), _status_description(other._status_description), 
+_headers(other._headers), _transfer_type(other._transfer_type),
+_clients(other._clients), _message_body(other._message_body) {}
+
+Response::Response(Request& req, Server* server)
 {
-    static_cast<void>(object);
+    (void)server;
+    this->setStatusCode(req);
+    if (getStatusCode()[0] == '4')
+    {
+    }
 }
 
 /*============================================================================*/
@@ -25,18 +38,43 @@ Response::~Response()
 /*******************************  Overload  ***********************************/
 /*============================================================================*/
 
-Response& Response::operator=(const Response& other)
+Response&
+Response::operator=(const Response& rhs)
 {
-    (void)other;
+    this->_status_code = rhs._status_code;
+    this->_status_description = rhs._status_description;
+    this->_headers = rhs._headers;
+    this->_transfer_type = rhs._transfer_type;
+    this->_clients = rhs._clients;
+    this->_message_body = rhs._message_body;
     return (*this);
 }
+
 /*============================================================================*/
 /********************************  Getter  ************************************/
 /*============================================================================*/
 
+std::string 
+Response::getStatusCode() const
+{
+    return (this->_status_code);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
+
+void
+Response::setStatusCode(Request& request)
+{
+    this->_status_code = request.getStatusCode();
+}
+
+void
+Response::setStatusCode(std::string& status_code)
+{
+    this->_status_code = status_code;
+}
 
 /*============================================================================*/
 /******************************  Exception  ***********************************/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -134,15 +134,15 @@ Response::getStatusMessage(const std::string& code)
 }
 
 std::string
-Response::makeStartLine()
+Response::makeStatusLine()
 {
-    std::string start_line;
+    std::string status_line;
 
     this->setStatusCode(std::string("400"));
-    start_line = "HTTP/1.1 ";
-    start_line += this->getStatusCode();
-    start_line += " ";
-    start_line += this->getStatusMessage(this->getStatusCode());
-    start_line += "\r\n";
-    return (start_line);
+    status_line = "HTTP/1.1 ";
+    status_line += this->getStatusCode();
+    status_line += " ";
+    status_line += this->getStatusMessage(this->getStatusCode());
+    status_line += "\r\n";
+    return (status_line);
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -10,18 +10,16 @@
 /*============================================================================*/
 
 Response::Response()
-: _status_code(""), _status_description(""), _transfer_type(""),
-_clients(""), _message_body("") 
+: _status_code(""), _transfer_type(""), _clients(""), _message_body("") 
 {
     this->_headers = { {"", ""} };
     this->initStatusCodeTable();
 }
 
 Response::Response(const Response& other)
-: _status_code(other._status_code), _status_description(other._status_description), 
-_headers(other._headers), _transfer_type(other._transfer_type),
-_clients(other._clients), _message_body(other._message_body),
-_status_code_table(other._status_code_table) {}
+: _status_code(other._status_code),  _headers(other._headers),
+_transfer_type(other._transfer_type), _clients(other._clients),
+_message_body(other._message_body), _status_code_table(other._status_code_table) {}
 
 /*============================================================================*/
 /******************************  Destructor  **********************************/
@@ -39,7 +37,6 @@ Response&
 Response::operator=(const Response& rhs)
 {
     this->_status_code = rhs._status_code;
-    this->_status_description = rhs._status_description;
     this->_headers = rhs._headers;
     this->_transfer_type = rhs._transfer_type;
     this->_clients = rhs._clients;
@@ -69,15 +66,9 @@ Response::setStatusCode(Request& request)
 }
 
 void
-Response::setStatusCode(std::string& status_code)
+Response::setStatusCode(const std::string& status_code)
 {
     this->_status_code = status_code;
-}
-
-void
-Response::setStatusDescription()
-{
-    this->_status_description = this->_status_code_table[this->getStatusCode()];
 }
 
 /*============================================================================*/
@@ -92,7 +83,6 @@ void
 Response::init()
 {
     this->_status_code = "";
-    this->_status_description = "";
     this->_headers = { {"", ""} };
     this->_transfer_type = "";
     this->_clients = "";
@@ -135,4 +125,24 @@ Response::initStatusCodeTable()
         {"416", "Requested Range Not Satisfiable"},
         {"417", "Expectation Failed"}
     };
+}
+
+std::string
+Response::getStatusMessage(const std::string& code)
+{
+    return (this->_status_code_table[code]);
+}
+
+std::string
+Response::makeStartLine()
+{
+    std::string start_line;
+
+    this->setStatusCode(std::string("400"));
+    start_line = "HTTP/1.1 ";
+    start_line += this->getStatusCode();
+    start_line += " ";
+    start_line += this->getStatusMessage(this->getStatusCode());
+    start_line += "\r\n";
+    return (start_line);
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -99,17 +99,18 @@ Response::init()
     this->_message_body = "";
 }
 
-//TODO Not yet completed
-void 
-Response::initAndUpdate(Request& request)
-{
-    this->init();
-    this->setStatusCode(request);
-    if (this->getStatusCode()[0] != '4')
-    {
-    }
-    this->setStatusDescription();
-}
+// void 
+// Response::initAndUpdate(Request& request)
+// {
+//     this->init();
+//     this->setStatusCode(request);
+//     if (this->getStatusCode()[0] != '4')
+//     {
+//         // 헤더를 읽어서 필요한 응답 생성 하며 상태코드 셋팅
+//         // ex) CGI 실행, html body 불러오기
+//     }
+//     this->setStatusDescription();
+// }
 
 void
 Response::initStatusCodeTable()

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1,4 +1,5 @@
 #include "Response.hpp"
+#include "Server.hpp"
 
 /*============================================================================*/
 /****************************  Static variables  ******************************/
@@ -9,22 +10,18 @@
 /*============================================================================*/
 
 Response::Response()
-: _status_code(""), _status_description(""), _headers(""), _transfer_type(""),
-_clients(""), _message_body("") {}
+: _status_code(""), _status_description(""), _transfer_type(""),
+_clients(""), _message_body("") 
+{
+    this->_headers = { {"", ""} };
+    this->initStatusCodeTable();
+}
 
 Response::Response(const Response& other)
 : _status_code(other._status_code), _status_description(other._status_description), 
 _headers(other._headers), _transfer_type(other._transfer_type),
-_clients(other._clients), _message_body(other._message_body) {}
-
-Response::Response(Request& req, Server* server)
-{
-    (void)server;
-    this->setStatusCode(req);
-    if (getStatusCode()[0] == '4')
-    {
-    }
-}
+_clients(other._clients), _message_body(other._message_body),
+_status_code_table(other._status_code_table) {}
 
 /*============================================================================*/
 /******************************  Destructor  **********************************/
@@ -47,6 +44,7 @@ Response::operator=(const Response& rhs)
     this->_transfer_type = rhs._transfer_type;
     this->_clients = rhs._clients;
     this->_message_body = rhs._message_body;
+    this->_status_code_table = rhs._status_code_table;
     return (*this);
 }
 
@@ -76,6 +74,12 @@ Response::setStatusCode(std::string& status_code)
     this->_status_code = status_code;
 }
 
+void
+Response::setStatusDescription()
+{
+    this->_status_description = this->_status_code_table[this->getStatusCode()];
+}
+
 /*============================================================================*/
 /******************************  Exception  ***********************************/
 /*============================================================================*/
@@ -83,3 +87,51 @@ Response::setStatusCode(std::string& status_code)
 /*============================================================================*/
 /*********************************  Util  *************************************/
 /*============================================================================*/
+
+void
+Response::init()
+{
+    this->_status_code = "";
+    this->_status_description = "";
+    this->_headers = { {"", ""} };
+    this->_transfer_type = "";
+    this->_clients = "";
+    this->_message_body = "";
+}
+
+//TODO Not yet completed
+void 
+Response::initAndUpdate(Request& request)
+{
+    this->init();
+    this->setStatusCode(request);
+    if (this->getStatusCode()[0] != '4')
+    {
+    }
+    this->setStatusDescription();
+}
+
+void
+Response::initStatusCodeTable()
+{
+    this->_status_code_table = {
+        {"400", "Bad Request"},
+        {"401", "Unauthorized"},
+        {"402", "Payment Required"},
+        {"403", "Forbidden"},
+        {"404", "Not found"},
+        {"405", "Method Not Allowed"},
+        {"406", "Not Acceptable"},
+        {"407", "Proxy Authentication Required"},
+        {"408", "Required Timeout"},
+        {"409", "Conflict"},
+        {"410", "Gone"},
+        {"411", "Length Required"},
+        {"412", "Precondition Failed"},
+        {"413", "Request Entity Too Large"},
+        {"414", "Request URI Too Long"},
+        {"415", "Unsupported Media Type"},
+        {"416", "Requested Range Not Satisfiable"},
+        {"417", "Expectation Failed"}
+    };
+}

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -84,7 +84,7 @@ Server::init()
         else if (conf.first == "listen")
             this->_port = conf.second;
     }
-    this->_response = std::vector<Response>(1024);
+    this->_requests = std::vector<Request>(1024);
 
     if ((this->_server_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
         throw "Socket Error";
@@ -107,7 +107,7 @@ Server::init()
 }
 
 Request
-Server::receiveRequest(int fd)
+Server::receiveRequest(ServerManager* server_manager, int fd)
 {
     Request req;
     int bytes;
@@ -118,43 +118,69 @@ Server::receiveRequest(int fd)
     bytes = -42;
     memset(reinterpret_cast<void *>(buf), 0, BUFFER_SIZE + 1);
 
-    while ((len = recv(fd, buf, BUFFER_SIZE, MSG_PEEK)) > 0)
+    if ((len = recv(fd, buf, BUFFER_SIZE, MSG_PEEK)) > 0)
     {
-        if ((bytes = read(fd, buf, len)) < 0)
+        std::cout<<"len: "<<len<<std::endl;
+        if ((bytes = read(fd, buf, BUFFER_SIZE)) < 0)
         {
             req.setStatusCode("400");
             return (req);
         }
         buf[bytes] = 0;
         req_message += buf;
+        std::cout<<req_message<<std::endl;
+        server_manager->fdSet(fd, WRITE_FDSET);
     }
-
-    //TODO 우아한 종료 되었을 때 체크하기.
-    // if (len == 0)
+    else if (len == 0)
+    {
+        std::cout<<"len: 0"<<std::endl;
+        server_manager->fdClr(fd, READ_FDSET);
+        close(fd);
+        _client_sockets.erase(std::find(_client_sockets.begin(), _client_sockets.end(), fd));
+        //TODO setFdMax를 효율적으로 할것.
+        if (fd == server_manager->getFdMax())
+            server_manager->setFdMax(fd - 1);
+    }
+    else
+    {
+        std::cout<<"len: -1"<<std::endl;
+        req.setStatusCode("400");
+        server_manager->fdClr(fd, READ_FDSET);
+        close(fd);
+        _client_sockets.erase(std::find(_client_sockets.begin(), _client_sockets.end(), fd));
+        //TODO setFdMax를 효율적으로 할것.
+        if (fd == server_manager->getFdMax())
+            server_manager->setFdMax(fd - 1);
+    }
 
     if (bytes >= 0)
         req.parseRequest(req_message);
     return (req);
 }
 
-void
-Server::makeResponse(Request& request, int fd)
+std::string
+Server::makeResponseMessage(Request& request)
 {
-    if (static_cast<size_t>(fd) >= this->_response.size())
-    {
-        this->_response.resize(fd);
-        Response response;
-        response.initAndUpdate(request); 
-        this->_response[fd] = response;
-    }
-    else
-        this->_response[fd].initAndUpdate(request); 
+    // Response response;
+    std::string start_line;
+    std::string headers;
+    std::string body;
+
+    (void)request;
+    // body = response.makeBody(request);
+    // headers = response.makeHeaders(request);
+    // start_line = response.makeStartLine(request);
+    return (start_line + headers + body);
 }
 
 bool
-Server::sendResponse(int fd)
+Server::sendResponse(std::string& response_message, int fd)
 {
-    std::cout<<"in sendResponse fd: " << fd << std::endl;
+    (void)response_message;
+    std::string tmp = "fd: ";
+    tmp += std::to_string(fd);
+    tmp += " in send response\n";
+    write(fd, tmp.c_str(), tmp.length());
     return (true);
 }
 
@@ -193,24 +219,25 @@ Server::run(ServerManager *server_manager, int fd)
     {
         if (server_manager->fdIsSet(fd, WRITE_FDSET))
         {
+            std::string response_message;
+            response_message = this->makeResponseMessage(this->_requests[fd]);
             // TODO: sendResponse error handling
-            if (!(sendResponse(fd)))
+            if (!(sendResponse(response_message, fd)))
                 std::cerr<<"Error: sendResponse"<<std::endl;
             server_manager->fdClr(fd, WRITE_FDSET);
             //TODO: check chunked response before close(fd);
-            close(fd);
-            _client_sockets.erase(std::find(_client_sockets.begin(),
-                        _client_sockets.end(), fd));
+            // close(fd);
+            // _client_sockets.erase(std::find(_client_sockets.begin(),
+            //             _client_sockets.end(), fd));
             //TODO setFdMax를 효율적으로 할것.
-            if (fd == server_manager->getFdMax())
-                server_manager->setFdMax(fd - 1);
+            // if (fd == server_manager->getFdMax())
+            //     server_manager->setFdMax(fd - 1);
         }
         else if (server_manager->fdIsSet(fd, READ_FDSET))
         {
-            Request request(this->receiveRequest(fd));
-            this->makeResponse(request, fd);
-            server_manager->fdSet(fd, WRITE_FDSET);
-            server_manager->fdClr(fd, READ_FDSET);
+            Request request(this->receiveRequest(server_manager, fd));
+            // server_manager->fdSet(fd, WRITE_FDSET);
+            // server_manager->fdClr(fd, READ_FDSET);
         }
     }
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -144,13 +144,11 @@ Server::makeResponse(Request& request, int fd)
     {
         this->_response.resize(fd);
         Response response;
-        // response.resetAndUpdate(request, this); 
+        response.initAndUpdate(request); 
         this->_response[fd] = response;
     }
     else
-        this->_response[fd] = Response(request, this); 
-        // this->_response[fd].resetAndUpdate(request, this); 
-    // std::string res = "OPTION / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nUser-Agent: Mozilla/5.0 (Macintosh;) Firefox/51.0\r\nAccept-Charsets: text/html\r\nAccept-Language: en-US\r\nContent-Type: multipart/form-data\r\nContent-Length: 345\r\n\r\nHelloWorld, everybody, buddy, whatsup\r\n";
+        this->_response[fd].initAndUpdate(request); 
 }
 
 bool

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -10,14 +10,13 @@
 /******************************  Constructor  *********************************/
 /*============================================================================*/
 
-Server::Server(server_info& server_config, std::map<std::string, location_info> location_config)
+Server::Server(server_info& server_config, std::map<std::string, location_info>& location_config)
 : _server_config(server_config), _server_socket(-1),
 _client_sockets(0), _server_name(""), _host(""),
 _port(""), _status_code(0), _request_uri_limit_size(0),
-_request_header_limit_size(0), _limit_client_body_size(0), _default_error_page("")
+_request_header_limit_size(0), _limit_client_body_size(0),
+_default_error_page(""), _location_config(location_config)
 {
-    //TODO: location_config 를 서버에 반영
-    (void)location_config;
     try
     {
         this->init();
@@ -77,9 +76,9 @@ Server::init()
 {
     for (auto& conf: this->_server_config)
     {
-        if (conf.first == "server_name")
-            this->_server_name = conf.second;
-        else if (conf.first == "host")
+        // if (conf.first == "server_name")
+        //     this->_server_name = conf.second;
+        if (conf.first == "host")
             this->_host = conf.second;
         else if (conf.first == "listen")
             this->_port = conf.second;
@@ -159,33 +158,33 @@ Server::receiveRequest(ServerManager* server_manager, int fd)
 std::string
 Server::makeResponseMessage(Request& request)
 {
-    Response response;
-    std::string status_line;
-    std::string headers;
-    std::string body;
+    // Response response;
+    // std::string status_line;
+    // std::string headers;
+    // std::string body;
 
     // response.checkRequest(request);
     // body = response.makeBody(request);
     // headers = response.makeHeaders(request);
-    status_line = response.makeStatusLine();
-    return (status_line+ headers + body);
-    // std::string ret;
-    // std::string status_line =  "\033[1;31;40mStatus Line\033[0m\n" + request.getRequestMethod() + " " + request.getRequestUri() + request.getRequestVersion();
-    // ret = (status_line + "\n");
-    // std::cout << "\033[1;31;40mHEADERS\033[0m" << std::endl;
-    // std::string blue =  "\033[1;34;40m";
-    // std::string yellow =  "\033[1;33;40m";
-    // std::string reset = "\033[0m";
-    // std::string headers;
-    // for (auto& m : request.getRequestHeaders())
-    // {
-    //     headers += (blue + "key: " + reset + m.first );
-    //     headers += ("\n" + yellow + "value: " + reset + m.second + "\n");
-    // }
-    // ret += headers;
-    // std::string response_body = "\n\033[1;34;40mBody\033[0m\n" + request.getRequestBodies() + "\n";
-    // ret += response_body;
-    // return ret;
+    // status_line = response.makeStatusLine();
+    // return (status_line+ headers + body);
+    std::string ret;
+    std::string status_line =  "\033[1;31;40mStatus Line\033[0m\n" + request.getRequestMethod() + " " + request.getRequestUri() + request.getRequestVersion();
+    ret = (status_line + "\n");
+    std::cout << "\033[1;31;40mHEADERS\033[0m" << std::endl;
+    std::string blue =  "\033[1;34;40m";
+    std::string yellow =  "\033[1;33;40m";
+    std::string reset = "\033[0m";
+    std::string headers;
+    for (auto& m : request.getRequestHeaders())
+    {
+        headers += (blue + "key: " + reset + m.first );
+        headers += ("\n" + yellow + "value: " + reset + m.second + "\n");
+    }
+    ret += headers;
+    std::string response_body = "\n\033[1;34;40mBody\033[0m\n" + request.getRequestBodies() + "\n";
+    ret += response_body;
+    return ret;
 }
 
 bool

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -84,6 +84,7 @@ Server::init()
         else if (conf.first == "listen")
             this->_port = conf.second;
     }
+    this->_response = std::vector<Response>(1024);
 
     if ((this->_server_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
         throw "Socket Error";
@@ -92,7 +93,7 @@ Server::init()
     int option = true;
     setsockopt(_server_socket, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(int));
 
-    memset(&this->_server_address, 0, sizeof(this->_server_address));
+    ft::memset(&this->_server_address, 0, sizeof(this->_server_address));
     this->_server_address.sin_family = AF_INET;
     this->_server_address.sin_addr.s_addr = ft::hToNL(INADDR_ANY);
     this->_server_address.sin_port = ft::hToNS(stoi(this->_port));
@@ -136,13 +137,20 @@ Server::receiveRequest(int fd)
     return (req);
 }
 
-//TODO 이 부분 작업하기.
 void
 Server::makeResponse(Request& request, int fd)
 {
-    (void)fd;
-    (void)request;
-    std::string res = "OPTION / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nUser-Agent: Mozilla/5.0 (Macintosh;) Firefox/51.0\r\nAccept-Charsets: text/html\r\nAccept-Language: en-US\r\nContent-Type: multipart/form-data\r\nContent-Length: 345\r\n\r\nHelloWorld, everybody, buddy, whatsup\r\n";
+    if (static_cast<size_t>(fd) >= this->_response.size())
+    {
+        this->_response.resize(fd);
+        Response response;
+        // response.resetAndUpdate(request, this); 
+        this->_response[fd] = response;
+    }
+    else
+        this->_response[fd] = Response(request, this); 
+        // this->_response[fd].resetAndUpdate(request, this); 
+    // std::string res = "OPTION / HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nUser-Agent: Mozilla/5.0 (Macintosh;) Firefox/51.0\r\nAccept-Charsets: text/html\r\nAccept-Language: en-US\r\nContent-Type: multipart/form-data\r\nContent-Length: 345\r\n\r\nHelloWorld, everybody, buddy, whatsup\r\n";
 }
 
 bool

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -161,7 +161,7 @@ Server::receiveRequest(ServerManager* server_manager, int fd)
 std::string
 Server::makeResponseMessage(Request& request)
 {
-    // Response response;
+    Response response;
     std::string start_line;
     std::string headers;
     std::string body;
@@ -169,17 +169,20 @@ Server::makeResponseMessage(Request& request)
     (void)request;
     // body = response.makeBody(request);
     // headers = response.makeHeaders(request);
-    // start_line = response.makeStartLine(request);
+    start_line = response.makeStartLine();
     return (start_line + headers + body);
 }
 
 bool
 Server::sendResponse(std::string& response_message, int fd)
 {
-    (void)response_message;
     std::string tmp = "fd: ";
     tmp += std::to_string(fd);
     tmp += " in send response\n";
+    tmp += "===============================\n";
+    tmp += "response_message\n ";
+    tmp += "===============================\n";
+    tmp += response_message;
     write(fd, tmp.c_str(), tmp.length());
     return (true);
 }
@@ -225,19 +228,8 @@ Server::run(ServerManager *server_manager, int fd)
             if (!(sendResponse(response_message, fd)))
                 std::cerr<<"Error: sendResponse"<<std::endl;
             server_manager->fdClr(fd, WRITE_FDSET);
-            //TODO: check chunked response before close(fd);
-            // close(fd);
-            // _client_sockets.erase(std::find(_client_sockets.begin(),
-            //             _client_sockets.end(), fd));
-            //TODO setFdMax를 효율적으로 할것.
-            // if (fd == server_manager->getFdMax())
-            //     server_manager->setFdMax(fd - 1);
         }
         else if (server_manager->fdIsSet(fd, READ_FDSET))
-        {
             Request request(this->receiveRequest(server_manager, fd));
-            // server_manager->fdSet(fd, WRITE_FDSET);
-            // server_manager->fdClr(fd, READ_FDSET);
-        }
     }
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -160,15 +160,15 @@ std::string
 Server::makeResponseMessage(Request& request)
 {
     Response response;
-    std::string start_line;
+    std::string status_line;
     std::string headers;
     std::string body;
 
-    (void)request;
+    // response.checkRequest(request);
     // body = response.makeBody(request);
     // headers = response.makeHeaders(request);
-    start_line = response.makeStartLine();
-    return (start_line + headers + body);
+    status_line = response.makeStatusLine();
+    return (status_line+ headers + body);
     // std::string ret;
     // std::string status_line =  "\033[1;31;40mStatus Line\033[0m\n" + request.getRequestMethod() + " " + request.getRequestUri() + request.getRequestVersion();
     // ret = (status_line + "\n");

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -15,7 +15,6 @@ ServerManager::ServerManager(const char *config_path)
 {
     this->initServers();
 
-    //TODO: FD_ZERO 구현
     ft::fdZero(&this->_readfds);
     ft::fdZero(&this->_writefds);
     ft::fdZero(&this->_exceptfds);
@@ -28,11 +27,6 @@ ServerManager::ServerManager(const char *config_path)
     this->_port = "default";
     this->_fd = 0;
     this->_fd_max = 0;
-
-    this->_status_code_msg = {
-        {101, "wowowo"},
-        {102, "wowowo"}
-    };
 }
 
 /*============================================================================*/

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -2,7 +2,7 @@ http {
     include mime.types;
     root /test/folder;
     server {
-        server_name second_server;
+        server_name first_server;
         listen       8080;
         location /please {
             index  index.html index.htm;


### PR DESCRIPTION
1. client_socket 별 Response 생성방식을 수정했습니다.
- 기존: Server가 client에게 받은 Request에 대응하는 Response를 만들어서 vector에 임시저장한 다음, 저장된 Response를 참조하여 Response message를 만들어 송신함.
- 변경: Server가 client에게 받은 Request를 우선 vector에 임시저장한 다음, 저장된 Request를 참조하여 Response message를 만들어 송신함.

2. Response 객체가 status_code_table을 map 형태로 저장하도록 수정하였습니다.
3. Response 객체에 status_line 생성 함수를 추가했습니다.