### PR TITLE
Feat/server

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -32,7 +32,6 @@ private:
     ServerManager* _server_manager;
     std::map<std::string, std::string> _server_config;
     int _server_socket;
-    std::vector<int> _client_sockets;
     std::string _server_name;
     std::string _host;
     std::string _port;
@@ -44,7 +43,6 @@ private:
     struct sockaddr_in _server_address;
     std::vector<Request> _requests;
     std::map<std::string, location_info> _location_config;
-    std::map<int, int> _client_by_file_and_pipe;
 
 public:
     /* Constructor */
@@ -59,12 +57,17 @@ public:
     // Request getRequest();
     const std::map<std::string, std::string> getServerConfig();
     const std::map<std::string, location_info>& getLocationConfig();
-    int getServerSocket();
+    int getServerSocket() const;
     Request getRequest(int fd);
     /* Setter */
     void setServerSocket();
     /* Exception */
     /* Util */
+    bool isFdManagedByServer(int fd) const;
+    bool isServerSocket(int fd) const;
+    bool isClientSocket(int fd) const;
+    bool isStaticResource(int fd) const;
+    bool isCGIPipe(int fd) const;
 
     /* Server function */
     void init();
@@ -72,7 +75,7 @@ public:
     Request receiveRequest(ServerManager* server_manager, int fd);
     std::string makeResponseMessage(Request& request);
     bool sendResponse(std::string& response_meesage, int fd);
-    bool isClientOfServer(int fd);
+    bool isClientOfServer(int fd) const;
 };
 
 #endif

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -37,7 +37,7 @@ private:
     fd_set _copy_writefds;
     fd_set _copy_exceptfds;
     std::string _port;
-    std::vector<FdType> _fd_table;
+    std::vector<std::pair<FdType, int>> _fd_table;
     int _fd;
     int _fd_max;
 
@@ -50,9 +50,14 @@ public:
     /* Getter */
     const char *getConfigFilePath() const;
     int getFdMax() const;
+    const std::vector<std::pair<FdType, int> >& getFdTable() const;
     /* Setter */
     void setFdMax(int fd);
-    void updateFdTableFds(int fd, FdType type);
+    void setServerSocketOnFdTable(int fd);
+    void setClientSocketOnFdTable(int fd, int server_socket);
+    void setResourceOnFdTable(int fd, int client_socket);
+    void setCGIPipeOnFdTable(int fd, int client_socket);
+    void setClosedFdOnFdTable(int fd);
     /* Exception */
     /* Util */
     bool fdIsSet(int fd, FdSet type);

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -20,7 +20,9 @@ ServerManager::ServerManager(const char *config_path)
     ft::fdZero(&this->_copy_writefds);
     ft::fdZero(&this->_copy_exceptfds);
     this->_port = "default";
-    this->_fd_table.resize(1024, FdType::CLOSED);
+    // this->_fd_table.resize(1024, FdType::CLOSED);
+
+    this->_fd_table.resize(1024, std::pair<FdType, int>(FdType::CLOSED, -1));
     this->_fd = 0;
     this->_fd_max = 2;
     this->initServers();
@@ -54,6 +56,12 @@ ServerManager::getFdMax() const
     return (this->_fd_max);
 }
 
+const std::vector<std::pair<FdType, int> >& 
+ServerManager::getFdTable() const
+{
+    return (this->_fd_table);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -65,9 +73,37 @@ ServerManager::setFdMax(int fd)
 }
 
 void
-ServerManager::updateFdTableFds(int fd, FdType type)
+ServerManager::setServerSocketOnFdTable(int fd)
 {
-    this->_fd_table[fd] = type;
+    this->_fd_table[fd].first = FdType::SERVER_SOCKET;
+    this->_fd_table[fd].second = -1;
+}
+
+void
+ServerManager::setClientSocketOnFdTable(int fd, int server_socket)
+{
+    this->_fd_table[fd].first = FdType::CLIENT_SOCKET;
+    this->_fd_table[fd].second = server_socket;
+}
+
+void
+ServerManager::setResourceOnFdTable(int fd, int client_socket)
+{
+    this->_fd_table[fd].first = FdType::RESOURCE;
+    this->_fd_table[fd].second = client_socket;
+}
+
+void
+ServerManager::setCGIPipeOnFdTable(int fd, int client_socket)
+{
+    this->_fd_table[fd].first = FdType::PIPE;
+    this->_fd_table[fd].second = client_socket;
+}
+
+void
+ServerManager::setClosedFdOnFdTable(int fd)
+{
+    this->_fd_table[fd].first = FdType::CLOSED;
 }
 
 /*============================================================================*/
@@ -152,14 +188,14 @@ ServerManager::fdClr(int fd, FdSet type)
 void
 ServerManager::updateFdMax(int fd)
 {
-    switch (this->_fd_table[fd])
+    switch (this->_fd_table[fd].first)
     {
     case FdType::CLOSED:
         if (this->_fd_max == fd)
         {
             for (int i = fd - 1; i > 2; i--)
             {
-                if (this->_fd_table[i] != FdType::CLOSED)
+                if (this->_fd_table[i].first != FdType::CLOSED)
                 {
                     this->setFdMax(i);
                     break ;
@@ -227,8 +263,8 @@ ServerManager::runServers()
                 {
                     for (Server *server : this->_servers)
                     {
-                        if (fd == server->getServerSocket() ||
-                            server->isClientOfServer(fd))
+                        // if (fd == server->getServerSocket() || server->isClientOfServer(fd))
+                        if (fd == server->getServerSocket() || server->isFdManagedByServer(fd))
                             server->run(fd);
                     }
                 }


### PR DESCRIPTION
기존에는 ServerManager에 1024 크기의 벡터 (`std::vector<int> _fd_table`)를 만들어서 모든 open 된 FD 들은 fd_table에서 관리되었습니다.

- `fd_table`의 인덱스가 어떤 종류의 Fd인지를 모른다는 단점이 있었습니다.
  - 이 문제를 해결하고자 `enum class FdType`를 이전 커밋에서 만들었었습니다.

- 이렇게 하면 어느정도의 문제는 해결되지만 각 서버마다 또 자신들과 관련된 FD를 저장할 변수를 만들어야 하는 문제가 발생했습니다.

  - 이 문제를 해결하기 위해 `_fd_table`의 형태를 수정했습니다. 변경된 형태는 아래와 같습니다. `std::vector<std::pair<FdType, int> > _fd_table`

간단하게 설정하자면 관리해야 할 FD가 생성될 때, FD의 값을 인덱스로해서 `_fd_table`에 접근합니다. 그리고 `first`를 해당하는 타입으로 설정해주고, int에는 ***관계된 fd***를 넣어줍니다.
- 관계된 fd란?
  - type이 Client라면 관계된 Fd는 자신을 갖는 Server의 FD가 됩니다.
  - type이 Resource라면 관계된 Fd는 자신을 갖는 Client의 FD가 됩니다.
  - type이 Pipe라면 관계된 Fd는 자신을 갖는 Client의 FD가 됩니다.
  - type이 Server라면 -1를 넣어줍니다.

따라서 각 FD를 타입에 맞게 세팅하는 `setter` 함수를 만들었습니다.
또한 `Is~` 함수도 만들어서 bool 타입을 반환 할 수 도 있게 만들었습니다. 이 함수는 `ServerManager`의 `runServers`에서 for을 순회하는 FD가 어디에 속하는지 알 수 있게 만들어줍니다.