### PR TITLE
FEAT: server's default router = '/'

### DIFF
--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -67,6 +67,9 @@ public:
          std::vector<std::string>::iterator&,
          server_info&,
          std::map<std::string, location_info>&) = &ServerGenerator::parseServerBlock;
+
+    void defaultRoute(std::map<std::string,
+            location_info>& locations, server_info& server_config);
 };
 
 void testLocationConfig(std::map<std::string, location_info>& test);

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -68,7 +68,7 @@ public:
          server_info&,
          std::map<std::string, location_info>&) = &ServerGenerator::parseServerBlock;
 
-    void setDefaultRouteToServer(std::map<std::string,
+    void setDefaultRouteOfServer(std::map<std::string,
             location_info>& locations, server_info& server_config);
 };
 

--- a/include/ServerGenerator.hpp
+++ b/include/ServerGenerator.hpp
@@ -68,7 +68,7 @@ public:
          server_info&,
          std::map<std::string, location_info>&) = &ServerGenerator::parseServerBlock;
 
-    void defaultRoute(std::map<std::string,
+    void setDefaultRouteToServer(std::map<std::string,
             location_info>& locations, server_info& server_config);
 };
 

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -83,14 +83,14 @@ ServerGenerator::defaultRoute(std::map<std::string, location_info>& locations,
 
     if (locations.size() == 0)
     {
-        initLocationConfig(info, server_config);
+        this->initLocationConfig(info, server_config);
         locations["/"] = info;
     }
     else
     {
         if (locations.find("/") != locations.end())
             return ;
-        initLocationConfig(info, server_config);
+        this->initLocationConfig(info, server_config);
         locations["/"] = info;
     }
 }
@@ -103,18 +103,18 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
     
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
     std::vector<std::string>::iterator ite = this->_configfile_lines.end();
-    http_config = parseHttpBlock();
+    http_config = this->parseHttpBlock();
 
     while (it != ite)
     {
         if ( *it == "server {")
         {
             server_info server_config;
-            initServerConfig(server_config, http_config);
+            this->initServerConfig(server_config, http_config);
             it++;
             std::map<std::string, location_info> locations;
-            parseServerBlock(it, server_config, locations);
-            defaultRoute(locations, server_config);
+            this->parseServerBlock(it, server_config, locations);
+            this->defaultRoute(locations, server_config);
             // testServerConfig(server_config);
             // testLocationConfig(locations);
             servers.push_back(new Server(this->_server_manager, server_config, locations));
@@ -132,7 +132,7 @@ ServerGenerator::parseHttpBlock()
     std::vector<std::string>::iterator it = this->_configfile_lines.begin();
     std::vector<std::string>::iterator ite = this->_configfile_lines.end();
 
-    initHttpConfig(http_config);
+    this->initHttpConfig(http_config);
     while (it != ite)
     {
         if (*it == "http {")
@@ -160,12 +160,12 @@ ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, server
 {
     std::vector<std::string>	directives;
 
-    while (it != _configfile_lines.end())
+    while (it != this->_configfile_lines.end())
     {
         directives = ft::split(*it, " ");
         if (directives[0] == "location")
         {
-            location_info location_config = parseLocationBlock(it, server_config);
+            location_info location_config = this->parseLocationBlock(it, server_config);
             locations[location_config["route"]] = location_config;
             continue ;
         }
@@ -185,8 +185,8 @@ ServerGenerator::parseLocationBlock(std::vector<std::string>::iterator& it, serv
     std::vector<std::string> directives;
     location_info location_config;
 
-    initLocationConfig(location_config, server_config);
-    while (it != _configfile_lines.end())
+    this->initLocationConfig(location_config, server_config);
+    while (it != this->_configfile_lines.end())
     {
         directives = ft::split(*it, " ");
         if (directives[0] == "location")

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -75,6 +75,26 @@ ServerGenerator::convertFileToStringVector(const char *config_file_path)
     }
 }
 
+void
+ServerGenerator::defaultRoute(std::map<std::string, location_info>& locations,
+                            server_info& server_config)
+{
+    location_info info;
+
+    if (locations.size() == 0)
+    {
+        initLocationConfig(info, server_config);
+        locations["/"] = info;
+    }
+    else
+    {
+        if (locations.find("/") != locations.end())
+            return ;
+        initLocationConfig(info, server_config);
+        locations["/"] = info;
+    }
+}
+
 void 
 ServerGenerator::generateServers(std::vector<Server *>& servers)
 {
@@ -94,6 +114,7 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
             it++;
             std::map<std::string, location_info> locations;
             parseServerBlock(it, server_config, locations);
+            defaultRoute(locations, server_config);
             // testServerConfig(server_config);
             // testLocationConfig(locations);
             servers.push_back(new Server(this->_server_manager, server_config, locations));
@@ -145,8 +166,7 @@ ServerGenerator::parseServerBlock(std::vector<std::string>::iterator& it, server
         if (directives[0] == "location")
         {
             location_info location_config = parseLocationBlock(it, server_config);
-            std::string temp = location_config["route"];
-            locations[temp] = location_config;
+            locations[location_config["route"]] = location_config;
             continue ;
         }
         if (directives[0] == "}")

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -75,11 +75,8 @@ ServerGenerator::convertFileToStringVector(const char *config_file_path)
     }
 }
 
-// void
-// ServerGenerator::defaultRoute(std::map<std::string, location_info>& locations,
-//                             server_info& server_config)
 void
-ServerGenerator::setDefaultRouteToServer(std::map<std::string, location_info>& locations,
+ServerGenerator::setDefaultRouteOfServer(std::map<std::string, location_info>& locations,
                             server_info& server_config)
 {
     location_info info;
@@ -117,7 +114,7 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
             it++;
             std::map<std::string, location_info> locations;
             this->parseServerBlock(it, server_config, locations);
-            this->setDefaultRouteToServer(locations, server_config);
+            this->setDefaultRouteOfServer(locations, server_config);
             // testServerConfig(server_config);
             // testLocationConfig(locations);
             servers.push_back(new Server(this->_server_manager, server_config, locations));

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -75,8 +75,11 @@ ServerGenerator::convertFileToStringVector(const char *config_file_path)
     }
 }
 
+// void
+// ServerGenerator::defaultRoute(std::map<std::string, location_info>& locations,
+//                             server_info& server_config)
 void
-ServerGenerator::defaultRoute(std::map<std::string, location_info>& locations,
+ServerGenerator::setDefaultRouteToServer(std::map<std::string, location_info>& locations,
                             server_info& server_config)
 {
     location_info info;
@@ -114,7 +117,7 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
             it++;
             std::map<std::string, location_info> locations;
             this->parseServerBlock(it, server_config, locations);
-            this->defaultRoute(locations, server_config);
+            this->setDefaultRouteToServer(locations, server_config);
             // testServerConfig(server_config);
             // testLocationConfig(locations);
             servers.push_back(new Server(this->_server_manager, server_config, locations));

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -4,14 +4,6 @@ http {
     server {
         server_name first_server;
         listen       8080;
-        location / {
-            index  index.html index.htm;
-        }
-        location /one/two {
-            root  /user/iwoo;
-            index  html;
-            limit_except PUT
-        }
     }
     server {
         server_name second_server;


### PR DESCRIPTION
이전에는 서버블록에 로케이션이 없는 경우가 있을 수 있었습니다. 이렇게 될 경우 로케이션에서 찾을 수 있는 정보를 반드시 서버에서만 찾아야 하기 때문에 로케이션이 있는 블록, 없는 블록을 나눠서 검사를 해야하는 불편함이 있었습니다. 
따라서 만약에 로케이션 블록에 `/`가 없거나 또는 라우팅 주소가 하나도 없는 경우에 `/`를 라우팅 주소로 추가시켜줬습니다.
