### PR TITLE
Feat/log bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC = clang++
 CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 DEBUG = -D DEBUG=1
-STDOUT = -D STDOUT=1
+STDOUT = -D STDOUT=0
 
 MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request
 # MAIN_FILES = getCurrentDateTime_test utils
@@ -32,6 +32,7 @@ RESET = \033[0m
 all: $(NAME)
 
 ${NAME}: ${OBJS}
+	@mkdir log
 	@echo "$(GREEN)Making START$(RESET)"
 	@${CC} ${CFLAGS} ${INCLUDES} ${OBJS} -o ${NAME}
 	@echo "$(GREEN)DONE"

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -32,6 +32,7 @@ namespace ft
     int stoiHex(const std::string& str);
 
     std::string getCurrentDateTime();
+    size_t strlen(const char* str);
 }
 
 #endif

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -48,7 +48,7 @@ Log::timeLog(int fd)
     ft::memset(buf, 0, sizeof(buf));
     strptime(std::to_string(tv.tv_sec).c_str(), "%s", &time);
     strftime(buf, sizeof(buf), "[%d/%b/%Y/%X %Z] ", &time);
-    write(fd, static_cast<void *>(buf), sizeof(buf));
+    write(fd, static_cast<void *>(buf), ft::strlen(buf));
 }
 
 void
@@ -61,8 +61,8 @@ Log::serverIsCreated(Server& server)
     int server_fd = server.getServerSocket();
     int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
-    line = ("SERVER(\033[1;31;40m" + std::to_string(server_fd) +
-            "\033[0m) HAS CREATED\n");
+    line = ("SERVER(" + std::to_string(server_fd) +
+            ") HAS CREATED\n");
     Log::timeLog(fd);
     write(fd, line.c_str(), line.length());
 }
@@ -77,9 +77,9 @@ Log::newClient(Server& server, int client_fd)
     int server_fd = server.getServerSocket();
     int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
-    line = ("SERVER(\033[1;31;40m" + std::to_string(server_fd) +
-            "\033[0m) HAS NEW CLIENT: \033[1;31;40m" +
-            std::to_string(client_fd) + "\033[0m\n");
+    line = ("SERVER(" + std::to_string(server_fd) +
+            ") HAS NEW CLIENT: " +
+            std::to_string(client_fd) + "\n");
     Log::timeLog(fd);
     write(fd, line.c_str(), line.length());
 }
@@ -94,9 +94,9 @@ Log::closeClient(Server& server, int client_fd)
     int server_fd = server.getServerSocket();
     int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
-    line = ("SERVER(\033[1;31;40m" + std::to_string(server_fd) +
-            "\033[0m) BYBY CLIENT(\033[1;31;40m" + std::to_string(client_fd)
-           + "\033[0m)\n");
+    line = ("SERVER(" + std::to_string(server_fd) +
+            ") BYBY CLIENT(" + std::to_string(client_fd)
+           + ")\n");
     Log::timeLog(fd);
     write(fd, line.c_str(), line.length());
 }
@@ -114,9 +114,9 @@ Log::getRequest(Server& server, int client_fd)
     std::string uri = server.getRequest(client_fd).getUri();
     std::string version = server.getRequest(client_fd).getVersion();
 
-    line = ("SERVER(\033[1;31;40m" + std::to_string(server_fd) +
-            "\033[0m) GOT REQUEST FROM: CLIENT(\033[1;31;40m" +
-            std::to_string(client_fd) + "\033[0m)" + " \"" + method + " " +
+    line = ("SERVER(" + std::to_string(server_fd) +
+            ") GOT REQUEST FROM: CLIENT(" +
+            std::to_string(client_fd) + ")" + " \"" + method + " " +
             uri + " "+ version + "\"\n");
     Log::timeLog(fd);
     write(fd, line.c_str(), line.length());

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -200,4 +200,13 @@ getCurrentDateTime()
     return (buf);
 }
 
+size_t
+strlen(const char* str)
+{
+    size_t i = 0;
+    while (str[i])
+        i++;
+    return (i);
+}
+
 }


### PR DESCRIPTION
로그 파일에 쓰레기 값이 담기는 문제는 두 가지 이유가 있었습니다.
1. write를 사이즈대로 안해준 것.
2. 색 정보

따라서 write를 해줄 때 `strlen`을 사용해서 제대로 동작하게 만들었고 색은 삭제했습니다