### PR TITLE
Feat/server receive request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CC = clang++
 CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 DEBUG = -D DEBUG=1
-STDOUT = -D STDOUT=0
+STDOUT = -D STDOUT=1
 
 # MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request
 MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request
@@ -32,12 +32,12 @@ RESET = \033[0m
 all: $(NAME)
 
 ${NAME}: ${OBJS}
-	@mkdir log
 	@echo "$(GREEN)Making START$(RESET)"
 	@${CC} ${CFLAGS} ${INCLUDES} ${OBJS} -o ${NAME}
 	@echo "$(GREEN)DONE"
 
 $(OBJDIR)/%.o : %.cpp
+	@mkdir -p $(LOGDIR)
 	@mkdir -p $(OBJDIR)
 	@${CC} ${CFLAGS} ${INCLUDES} ${DEBUG} ${STDOUT} -c $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ RM = rm -rf
 DEBUG = -D DEBUG=1
 STDOUT = -D STDOUT=1
 
+# MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request
 MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request
-# MAIN_FILES = getCurrentDateTime_test utils
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -2,6 +2,7 @@
 # define REQUEST_HPP
 
 # include "utils.hpp"
+# include "types.hpp"
 # include <map>
 
 //TODO: 테스트용
@@ -18,6 +19,8 @@ private:
     std::string _bodies;
     std::string _transfer_type;
     std::string _status_code;
+    ReqInfo _info;
+    size_t _header_end_pos;
 
 public:
     /* Constructor */
@@ -37,6 +40,8 @@ public:
     std::string getBodies();
     std::string getTransferType();
     std::string getStatusCode();
+    const ReqInfo& getReqInfo() const;
+    const size_t& getHeaderEndPos() const;
 
     /* Setter */
     void setMethod(const std::string& method);
@@ -47,14 +52,20 @@ public:
     void setBodies(const std::string& body);
     void setTransferType(const std::string& transfer_type);
     void setStatusCode(const std::string& code);
+    void setHeaderEndPos(const size_t& header_end_pos);
+    void setReqInfo(const ReqInfo& info);
 
     /* Exception */
 
     /* Util */
 
+    void clear();
+
     // void initMembers(std::string req_message);
 
     /* parser */
+    bool parseRequestWithoutBody(std::string& buf);
+
     bool parseRequest(std::string& req_message);
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
@@ -76,3 +87,4 @@ public:
 };
 
 #endif
+

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -19,7 +19,7 @@ private:
     std::string _bodies;
     std::string _status_code;
     ReqInfo _info;
-    bool _is_left_buffer;
+    bool _is_buffer_left;
 
 public:
     /* Constructor */
@@ -40,7 +40,7 @@ public:
     std::string getTransferType();
     std::string getStatusCode();
     const ReqInfo& getReqInfo() const;
-    bool getIsLeftBuffer() const;
+    bool getIsBufferLeft() const;
 
     /* Setter */
     void setMethod(const std::string& method);
@@ -52,7 +52,7 @@ public:
     void setTransferType(const std::string& transfer_type);
     void setStatusCode(const std::string& code);
     void setReqInfo(const ReqInfo& info);
-    void setIsLeftBuffer(const bool& is_left_buffer);
+    void setIsBufferLeft(const bool& is_left_buffer);
 
     /* Util */
 
@@ -99,7 +99,7 @@ public:
     public:
         RequestFormatException(Request& req, const std::string& status_code);
         RequestFormatException(Request& req);
-        virtual const char* what() const throw();
+        virtual std::string s_what() const throw();
     };
 };
 

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -5,6 +5,9 @@
 # include "types.hpp"
 # include <map>
 
+//NOTE: test용으로 ostream include함.
+#include <iostream>
+
 class Request
 {
 private:
@@ -99,6 +102,8 @@ public:
         virtual const char* what() const throw();
     };
 };
+
+std::ostream& operator<<(std::ostream& out, Request& object);
 
 #endif
 

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -68,11 +68,11 @@ public:
     // void initMembers(std::string req_message);
 
     /* parser */
-    void parseRequestWithoutBody(std::string& buf);
+    void parseRequestWithoutBody(char* buf);
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
     void parseNormalBodies(char* buf);
-    void parseChunkedBody(std::string &req_message);
+    void parseChunkedBody(char* buf);
 
     /* valid check */
     bool isValidLine(std::vector<std::string>& request_line);

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -16,7 +16,7 @@ private:
     std::string _bodies;
     std::string _status_code;
     ReqInfo _info;
-    size_t _header_end_pos;
+    bool _is_left_buffer;
 
 public:
     /* Constructor */
@@ -37,7 +37,7 @@ public:
     std::string getTransferType();
     std::string getStatusCode();
     const ReqInfo& getReqInfo() const;
-    const size_t& getHeaderEndPos() const;
+    bool getIsLeftBuffer() const;
 
     /* Setter */
     void setMethod(const std::string& method);
@@ -48,8 +48,8 @@ public:
     void setBodies(const std::string& body);
     void setTransferType(const std::string& transfer_type);
     void setStatusCode(const std::string& code);
-    void setHeaderEndPos(const size_t& header_end_pos);
     void setReqInfo(const ReqInfo& info);
+    void setIsLeftBuffer(const bool& is_left_buffer);
 
     /* Util */
 
@@ -61,6 +61,9 @@ public:
     bool isBodyUnnecessary() const;
     bool isNormalBody() const;
     bool isChunkedBody() const;
+    bool isContentLeftInBuffer() const;
+
+    int getContentLength();
 
     // void initMembers(std::string req_message);
 
@@ -68,7 +71,7 @@ public:
     void parseRequestWithoutBody(std::string& buf);
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
-    void parseNormalBodies(std::string& req_message);
+    void parseNormalBodies(char* buf);
     void parseChunkedBody(std::string &req_message);
 
     /* valid check */

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -5,9 +5,6 @@
 # include "types.hpp"
 # include <map>
 
-//TODO: 테스트용
-# include <iostream>
-
 class Request
 {
 private:
@@ -54,12 +51,13 @@ public:
     void setHeaderEndPos(const size_t& header_end_pos);
     void setReqInfo(const ReqInfo& info);
 
-    /* Exception */
-
     /* Util */
 
     void clear();
+
     void updateReqInfo();
+    bool updateStatusCodeAndReturn(const std::string& status_code, const bool& ret);
+
     bool isBodyUnnecessary() const;
     bool isNormalBody() const;
     bool isChunkedBody() const;
@@ -67,13 +65,11 @@ public:
     // void initMembers(std::string req_message);
 
     /* parser */
-    bool parseRequestWithoutBody(std::string& buf);
-
-    bool parseRequest(std::string& req_message);
+    void parseRequestWithoutBody(std::string& buf);
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
-    bool parseBodies(std::string& req_message);
-    bool parseChunkedBody(std::string &req_message);
+    void parseNormalBodies(std::string& req_message);
+    void parseChunkedBody(std::string &req_message);
 
     /* valid check */
     bool isValidLine(std::vector<std::string>& request_line);
@@ -85,8 +81,20 @@ public:
     bool isValidHeaderFields(std::string& key);
     bool isValidSP(std::string& str);
     bool isDuplicatedHeader(std::string& key);
-
     bool isValidBodies();
+
+    /* Exception */
+public:
+    class RequestFormatException : public std::exception
+    {
+    private:
+        std::string _msg;
+        Request& _req;
+    public:
+        RequestFormatException(Request& req, const std::string& status_code);
+        RequestFormatException(Request& req);
+        virtual const char* what() const throw();
+    };
 };
 
 #endif

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -17,7 +17,6 @@ private:
     std::map<std::string, std::string> _headers;
     std::string _protocol;
     std::string _bodies;
-    std::string _transfer_type;
     std::string _status_code;
     ReqInfo _info;
     size_t _header_end_pos;
@@ -32,10 +31,10 @@ public:
     virtual ~Request();
 
     /* Getter */
-    std::string getMethod();
+    std::string getMethod() const;
     const std::string& getUri();
     std::string getVersion();
-    std::map<std::string, std::string> getHeaders();
+    std::map<std::string, std::string> getHeaders() const;
     std::string getProtocol();
     std::string getBodies();
     std::string getTransferType();
@@ -60,15 +59,17 @@ public:
     /* Util */
 
     void clear();
-
     void updateReqInfo();
+    bool isBodyUnnecessary() const;
+    bool isNormalBody() const;
+    bool isChunkedBody() const;
 
     // void initMembers(std::string req_message);
 
     /* parser */
-    void parseRequestWithoutBody(std::string& buf);
+    bool parseRequestWithoutBody(std::string& buf);
 
-    void parseRequest(std::string& req_message);
+    bool parseRequest(std::string& req_message);
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
     bool parseBodies(std::string& req_message);

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -61,12 +61,14 @@ public:
 
     void clear();
 
+    void updateReqInfo();
+
     // void initMembers(std::string req_message);
 
     /* parser */
-    bool parseRequestWithoutBody(std::string& buf);
+    void parseRequestWithoutBody(std::string& buf);
 
-    bool parseRequest(std::string& req_message);
+    void parseRequest(std::string& req_message);
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
     bool parseBodies(std::string& req_message);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -77,6 +77,8 @@ public:
     void receiveRequestWithoutBody(int fd);
     void readBufferUntilHeaders(int fd, char* buf, size_t header_end_pos);
     void receiveRequestNormalBody(int fd);
+    void receiveRequestChunkedBody(int fd);
+    void clearRequestBuffer(int fd);
     std::string makeResponseMessage(Request& request);
     bool sendResponse(std::string& response_meesage, int fd);
     bool isClientOfServer(int fd) const;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -92,6 +92,11 @@ public:
         PayloadTooLargeException(Request& request);
         virtual const char* what() const throw();
     };
+    class ReadErrorException : public std::exception
+    {
+    public:
+        virtual const char* what() const throw();
+    };
 
 // public:
 //     class ResponseException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -58,7 +58,7 @@ public:
     const std::map<std::string, std::string> getServerConfig();
     const std::map<std::string, location_info>& getLocationConfig();
     int getServerSocket() const;
-    Request getRequest(int fd);
+    Request& getRequest(int fd);
     /* Setter */
     void setServerSocket();
     /* Exception */
@@ -74,14 +74,20 @@ public:
     void init();
     void run(int fd);
     void receiveRequest(int fd);
+    void receiveRequestWithoutBody(int fd);
+    void readBufferUntilHeaders(int fd, char* buf, size_t header_end_pos);
+    void receiveRequestNormalBody(int fd);
     std::string makeResponseMessage(Request& request);
     bool sendResponse(std::string& response_meesage, int fd);
     bool isClientOfServer(int fd) const;
 
 public:
-    class ParseRequestException : public std::exception
+    class PayloadTooLargeException : public std::exception
     {
+    private:
+        Request& _request;
     public:
+        PayloadTooLargeException(Request& request);
         virtual const char* what() const throw();
     };
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -16,7 +16,7 @@
 # include "Request.hpp"
 # include "Response.hpp"
 
-const int BUFFER_SIZE = 9000;
+const int BUFFER_SIZE = 8192;
 
 class ServerManager;
 class Request;
@@ -63,6 +63,7 @@ public:
     void setServerSocket();
     /* Exception */
     /* Util */
+    bool closeClientSocket(int fd);
     bool isFdManagedByServer(int fd) const;
     bool isServerSocket(int fd) const;
     bool isClientSocket(int fd) const;
@@ -72,10 +73,24 @@ public:
     /* Server function */
     void init();
     void run(int fd);
-    Request receiveRequest(ServerManager* server_manager, int fd);
+    void receiveRequest(int fd);
     std::string makeResponseMessage(Request& request);
     bool sendResponse(std::string& response_meesage, int fd);
     bool isClientOfServer(int fd) const;
+
+public:
+    class ParseRequestException : public std::exception
+    {
+    public:
+        virtual const char* what() const throw();
+    };
+
+// public:
+//     class ResponseException : public std::exception
+//     {
+//     public:
+//         virtual const char* what() const throw();
+//     };
 };
 
 #endif

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -46,7 +46,7 @@ enum class FdSet
     ALL,
     READ,
     WRITE,
-    EXCEPT, 
+    EXCEPT,
 };
 
 enum class FdType
@@ -63,7 +63,8 @@ enum class ReqInfo
     READY,
     COMPLETE,
     NORMAL_BODY,
-    CHUNKED_BODY
+    CHUNKED_BODY,
+    MUST_CLEAR,
 };
 
 #endif

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -58,4 +58,12 @@ enum class FdType
     CLOSED,
 };
 
+enum class ReqInfo
+{
+    READY,
+    COMPLETE,
+    NORMAL_BODY,
+    CHUNKED_BODY
+};
+
 #endif

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -10,11 +10,11 @@
 
 int
 Log::access_fd = open("./log/access_log",
-        O_CREAT | O_APPEND | O_WRONLY, 0644);
+        O_CREAT | O_TRUNC | O_WRONLY, 0644);
 
 int
 Log::error_fd = open("./log/error_log",
-        O_CREAT | O_APPEND | O_WRONLY, 0644);
+        O_CREAT | O_TRUNC | O_WRONLY, 0644);
 
 /*============================================================================*/
 /******************************  Destructor  **********************************/

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -114,10 +114,18 @@ Log::getRequest(Server& server, int client_fd)
     std::string uri = server.getRequest(client_fd).getUri();
     std::string version = server.getRequest(client_fd).getVersion();
 
-    line = ("SERVER(" + std::to_string(server_fd) +
-            ") GOT REQUEST FROM: CLIENT(" +
-            std::to_string(client_fd) + ")" + " \"" + method + " " +
-            uri + " "+ version + "\"\n");
+    if (!method.empty() && !uri.empty() && !version.empty())
+    {
+        line = ("SERVER(" + std::to_string(server_fd) +
+                ") GOT REQUEST FROM: CLIENT(" +
+                std::to_string(client_fd) + ")" + " \"" + method + " " +
+                uri + " "+ version + "\"\n");
+    }
+    else
+    {
+        line = ("SERVER(" + std::to_string(server_fd) + ") READ CLIENT(" +
+        std::to_string(client_fd) + ") BUFFER BUT EMPTY NOW\n"); 
+    }
     Log::timeLog(fd);
     write(fd, line.c_str(), line.length());
 }

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -235,9 +235,10 @@ Request::updateStatusCodeAndReturn(const std::string& status_code, const bool& r
 }
 
 void
-Request::parseRequestWithoutBody(std::string& req_message)
+Request::parseRequestWithoutBody(char* buf)
 {
     std::string line;
+    std::string req_message(buf);
 
     if (ft::substr(line, req_message, "\r\n") == false)
         throw (RequestFormatException(*this, "400"));
@@ -253,6 +254,7 @@ Request::parseRequestWithoutBody(std::string& req_message)
         if (parseHeaders(line) == false)
             throw (RequestFormatException(*this));
     }
+    this->updateReqInfo();
 }
 
 bool
@@ -294,10 +296,11 @@ Request::parseHeaders(std::string& req_message)
 }
 
 void
-Request::parseChunkedBody(std::string &req_message)
+Request::parseChunkedBody(char* buf)
 {
     int line_len;
     std::string line;
+    std::string req_message(buf);
 
     if (req_message.find("\r\n") == std::string::npos)
     {
@@ -335,6 +338,7 @@ Request::parseNormalBodies(char* buf)
 {
     std::string normal_body(buf);
     this->setBodies(normal_body);
+    this->setReqInfo(ReqInfo::COMPLETE);
 }
 
 void

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -11,13 +11,14 @@
 Request::Request()
 : _method(""), _uri(""), _version(""),
  _protocol(""), _bodies(""), _transfer_type(""), 
- _status_code("") {}
+ _status_code(""), _info(ReqInfo::READY) {}
 
 Request::Request(const Request& other)
 : _method(other._method), _uri(other._uri), 
 _version(other._version), _headers(other._headers),
 _protocol(other._protocol), _bodies(other._bodies), 
-_transfer_type(other._transfer_type), _status_code(other._status_code) {}
+_transfer_type(other._transfer_type), _status_code(other._status_code), 
+_info(other._info) {}
 
 Request&
 Request::operator=(const Request& other)
@@ -30,6 +31,7 @@ Request::operator=(const Request& other)
     this->_bodies = other._bodies;
     this->_transfer_type = other._transfer_type;
     this->_status_code = other._status_code;
+    this->_info = other._info;
     return (*this);
 }
 
@@ -91,6 +93,18 @@ Request::getStatusCode()
     return (this->_status_code);
 }
 
+const ReqInfo&
+Request::getReqInfo() const
+{
+    return (this->_info);
+}
+
+const size_t&
+Request::getHeaderEndPos() const
+{
+    return (this->_header_end_pos);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -144,6 +158,12 @@ Request::setStatusCode(const std::string& status_code)
     this->_status_code = status_code;
 }
 
+void
+Request::setReqInfo(const ReqInfo& info)
+{
+    this->_info = info;
+}
+
 /*============================================================================*/
 /******************************  Exception  ***********************************/
 /*============================================================================*/
@@ -152,7 +172,7 @@ Request::setStatusCode(const std::string& status_code)
 /*********************************  Util  *************************************/
 /*============================================================================*/
 
-bool
+void
 Request::parseRequest(std::string& req_message)
 {
     std::string line;
@@ -284,6 +304,18 @@ Request::parseBodies(std::string& req_message)
 {
     this->setBodies(req_message);
     return (true);
+}
+
+void
+Request::clear()
+{
+    this->_method = "";
+    this->_uri = "";
+    this->_version = "";
+    this->_protocol = "";
+    this->_transfer_type = "";
+    this->_status_code = "";
+    this->_info = ReqInfo::READY;
 }
 
 /*============================================================================*/

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -215,7 +215,7 @@ Request::updateReqInfo()
 bool
 Request::isBodyUnnecessary() const
 {
-    std::string method = this->getMethod();
+    const std::string& method = this->getMethod();
     if (method.compare("PUT") || method.compare("POST"))
         return (false);
     return (true);
@@ -227,9 +227,8 @@ Request::isNormalBody() const
     if (this->getReqInfo() == ReqInfo::COMPLETE)
         return (false);
 
-    std::map<std::string, std::string> headers = this->getHeaders();
-    location_info::iterator it;
-    it = headers.find("Transfer-Encoding");
+    const std::map<std::string, std::string>& headers = this->getHeaders();
+    const location_info::const_iterator it = headers.find("Transfer-Encoding");
     if (it != headers.end() && (it->second.find("chunked") != std::string::npos))
         return (false);
     return (true);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -16,7 +16,8 @@ Request::Request(const Request& other)
 : _method(other._method), _uri(other._uri), 
 _version(other._version), _headers(other._headers),
 _protocol(other._protocol), _bodies(other._bodies), 
-_status_code(other._status_code), _info(other._info) {}
+_status_code(other._status_code), _info(other._info),
+_is_buffer_left(false) {}
 
 Request&
 Request::operator=(const Request& other)
@@ -29,6 +30,7 @@ Request::operator=(const Request& other)
     this->_bodies = other._bodies;
     this->_status_code = other._status_code;
     this->_info = other._info;
+    this->_is_buffer_left = other._is_buffer_left;
     return (*this);
 }
 
@@ -91,9 +93,9 @@ Request::getReqInfo() const
 }
 
 bool
-Request::getIsLeftBuffer() const
+Request::getIsBufferLeft() const
 {
-    return (this->_is_left_buffer);
+    return (this->_is_buffer_left);
 }
 
 /*============================================================================*/
@@ -149,9 +151,9 @@ Request::setReqInfo(const ReqInfo& info)
 }
 
 void
-Request::setIsLeftBuffer(const bool& is_left_buffer)
+Request::setIsBufferLeft(const bool& is_left_buffer)
 {
-    this->_is_left_buffer = is_left_buffer;
+    this->_is_buffer_left = is_left_buffer;
 }
 
 /*============================================================================*/
@@ -167,10 +169,14 @@ Request::RequestFormatException::RequestFormatException(Request& req, const std:
 Request::RequestFormatException::RequestFormatException(Request& req)
 : _msg("RequestFormatException: Invalid Request Format: "), _req(req) {}
 
-const char*
-Request::RequestFormatException::what() const throw()
+std::string
+Request::RequestFormatException::s_what() const throw()
 {
-    return ((this->_msg + this->_req.getStatusCode()).c_str());
+    std::string tmp;
+    tmp += this->_msg;
+    tmp += this->_req.getStatusCode();
+    std::cout<<"in reqformat except: "<<tmp<<std::endl;
+    return (tmp);
 }
 
 /*============================================================================*/
@@ -239,7 +245,7 @@ Request::isChunkedBody() const
 bool
 Request::isContentLeftInBuffer() const
 {
-    return (this->getIsLeftBuffer());
+    return (this->getIsBufferLeft());
 }
 
 
@@ -367,6 +373,7 @@ Request::clear()
     this->_headers = {{"default", "default"}};
     this->_status_code = "";
     this->_bodies = "";
+    this->_is_buffer_left = false;
     this->setReqInfo(ReqInfo::READY);
 }
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -225,7 +225,6 @@ Request::parseRequestWithoutBody(std::string& req_message)
     }
     else
     {
-        std::cout << "Without Body\n" << line<< std::endl;
         if (parseHeaders(line) == false)
         {
             this->setStatusCode("400");
@@ -334,7 +333,6 @@ Request::parseHeaders(std::string& req_message)
 bool
 Request::parseChunkedBody(std::string &req_message)
 {
-    std::cout << "=================== Chunked!!!!!! " << std::endl;
     int line_len;
     std::string line;
 
@@ -342,7 +340,10 @@ Request::parseChunkedBody(std::string &req_message)
     {
         line_len = ft::stoiHex(line);
         if (line_len == 0)
+        {
+            this->setReqInfo(ReqInfo::COMPLETE);
             return (true);
+        }
         else if (line_len != -1)
         {
             if (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
@@ -353,7 +354,6 @@ Request::parseChunkedBody(std::string &req_message)
         else
             return (false);
     }
-    this->updateReqInfo();
 
 
     //TODO: CRLF 못찾았을 때 처리해주기.
@@ -363,15 +363,14 @@ Request::parseChunkedBody(std::string &req_message)
 bool
 Request::parseBodies(std::string& req_message)
 {
-    std::cout << "======================= normal !!!" << std::endl;
     this->setBodies(req_message);
+    this->setReqInfo(ReqInfo::COMPLETE);
     return (true);
 }
 
 void
 Request::clear()
 {
-    std::cout << "clear" << std::endl;
     this->_method = "";
     this->_uri = "";
     this->_version = "";

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -334,18 +334,15 @@ Request::parseHeaders(std::string& req_message)
 bool
 Request::parseChunkedBody(std::string &req_message)
 {
+    std::cout << "=================== Chunked!!!!!! " << std::endl;
     int line_len;
     std::string line;
 
     while (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
     {
-        std::cout << "in parse chunked! " << std::endl << line << std::endl;
         line_len = ft::stoiHex(line);
         if (line_len == 0)
-        {
-            // this->updateReqInfo();
             return (true);
-        }
         else if (line_len != -1)
         {
             if (ft::substr(line, req_message, "\r\n") == true && !req_message.empty())
@@ -356,7 +353,8 @@ Request::parseChunkedBody(std::string &req_message)
         else
             return (false);
     }
-    // this->updateReqInfo();
+    this->updateReqInfo();
+
 
     //TODO: CRLF 못찾았을 때 처리해주기.
     return (true);
@@ -365,22 +363,23 @@ Request::parseChunkedBody(std::string &req_message)
 bool
 Request::parseBodies(std::string& req_message)
 {
+    std::cout << "======================= normal !!!" << std::endl;
     this->setBodies(req_message);
-    std::cout << "normal body" << std::endl << req_message << std::endl;
     return (true);
 }
 
 void
 Request::clear()
 {
+    std::cout << "clear" << std::endl;
     this->_method = "";
     this->_uri = "";
     this->_version = "";
     this->_protocol = "";
     this->_status_code = "";
     this->_bodies = "";
-    this->_info = ReqInfo::READY;
-    std::cout << "clear??? " << std::endl;
+    this->setReqInfo(ReqInfo::READY);
+    // this->_info = ReqInfo::READY;
 }
 
 /*============================================================================*/

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -177,6 +177,22 @@ Request::RequestFormatException::what() const throw()
 /*********************************  Util  *************************************/
 /*============================================================================*/
 
+std::ostream& operator<< (std::ostream& out, Request& object)
+{
+    out << "============================= result =============================\n";
+    out << object.getMethod() << "\n";
+    out << object.getUri() << "\n";
+    out << object.getVersion() << "\n";
+
+    for (auto& kv : object.getHeaders())
+    {
+        out << kv.first << ": ";
+        out << kv.second << "\n";
+    }
+    out << "============================= end =============================" << "\n";
+    return (out);
+}
+
 void
 Request::updateReqInfo()
 {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -172,9 +172,9 @@ Server::receiveRequestWithoutBody(int fd)
         if ((header_end_pos = std::string(buf).find("\r\n\r\n")) != std::string::npos)
         {
             if (static_cast<size_t>(bytes) == header_end_pos + 4)
-                req.setIsLeftBuffer(false);
+                req.setIsBufferLeft(false);
             else
-                req.setIsLeftBuffer(true);
+                req.setIsBufferLeft(true);
             this->readBufferUntilHeaders(fd, buf, header_end_pos);
         }
         else
@@ -258,11 +258,11 @@ Server::receiveRequest(int fd)
     {
     case ReqInfo::READY:
         this->receiveRequestWithoutBody(fd);
-        break;
+        break ;
 
     case ReqInfo::NORMAL_BODY:
         this->receiveRequestNormalBody(fd);
-        break;
+        break ;
 
     case ReqInfo::CHUNKED_BODY:
         this->receiveRequestChunkedBody(fd);
@@ -418,7 +418,11 @@ Server::run(int fd)
             //TODO: Exception Class 만들고 ERROR ReqInfo 세팅하기.
             catch(const Request::RequestFormatException& e)
             {
-                std::cout<< "=====================>"<< this->_requests[fd].isContentLeftInBuffer()<< std::endl;
+                std::cout << "========================= In RequestFormatException ========================" << std::endl;
+                std::cout << e.s_what() << std::endl;
+                
+                std::cout << "Before: " << static_cast<int>(this->_requests[fd].getReqInfo()) << std::endl;
+                
                 if (this->_requests[fd].isContentLeftInBuffer())
                     this->_requests[fd].setReqInfo(ReqInfo::MUST_CLEAR);
                 else
@@ -426,6 +430,9 @@ Server::run(int fd)
                     this->_requests[fd].setReqInfo(ReqInfo::COMPLETE);
                     this->_server_manager->fdSet(fd, FdSet::WRITE);
                 }
+
+                std::cout << "After: " << static_cast<int>(this->_requests[fd].getReqInfo()) << std::endl;
+
             }
             catch(const ReadErrorException& e)
             {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -413,16 +413,9 @@ Server::run(int fd)
                     this->receiveRequest(fd);
                     Log::getRequest(*this, fd);
                 }
-                std::cout << this->_requests[fd] << std::endl;
             }
-            //TODO: Exception Class 만들고 ERROR ReqInfo 세팅하기.
             catch(const Request::RequestFormatException& e)
             {
-                std::cout << "========================= In RequestFormatException ========================" << std::endl;
-                std::cout << e.s_what() << std::endl;
-                
-                std::cout << "Before: " << static_cast<int>(this->_requests[fd].getReqInfo()) << std::endl;
-                
                 if (this->_requests[fd].isContentLeftInBuffer())
                     this->_requests[fd].setReqInfo(ReqInfo::MUST_CLEAR);
                 else
@@ -430,9 +423,6 @@ Server::run(int fd)
                     this->_requests[fd].setReqInfo(ReqInfo::COMPLETE);
                     this->_server_manager->fdSet(fd, FdSet::WRITE);
                 }
-
-                std::cout << "After: " << static_cast<int>(this->_requests[fd].getReqInfo()) << std::endl;
-
             }
             catch(const ReadErrorException& e)
             {
@@ -441,13 +431,11 @@ Server::run(int fd)
             }
             catch(const std::exception& e)
             {
-                // this->_server_manager->fdClr(fd, FdSet::READ);
                 this->closeClientSocket(fd);
                 std::cerr << e.what() << '\n';
             }
             catch(const char* e)
             {
-                // this->_server_manager->fdClr(fd, FdSet::READ);
                 this->closeClientSocket(fd);
                 std::cerr << e << '\n';
             }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -15,7 +15,7 @@ Server::Server(ServerManager* server_manager, server_info& server_config, std::m
 : _server_manager(server_manager), _server_config(server_config),
 _server_socket(-1), _server_name(""), _host(""), _port(""),
 _status_code(0), _request_uri_limit_size(0), _request_header_limit_size(0), 
-_limit_client_body_size(0), _default_error_page(""), 
+_limit_client_body_size(BUFFER_SIZE), _default_error_page(""), 
 _location_config(location_config)
 {
     try

--- a/tests/updateReqInfo_test.cpp
+++ b/tests/updateReqInfo_test.cpp
@@ -1,0 +1,44 @@
+#include "Request.hpp"
+
+void printReqInfo(std::string str, Request& req)
+{
+    std::string tmp(str);
+
+    std::cout<<tmp<<std::endl;
+    if (req.getReqInfo() == ReqInfo::READY)
+        std::cout<<"ReqInfo: READY"<<std::endl;
+    else if (req.getReqInfo() == ReqInfo::COMPLETE)
+        std::cout<<"ReqInfo: COMPLETE"<<std::endl;
+    else if (req.getReqInfo() == ReqInfo::NORMAL_BODY)
+        std::cout<<"ReqInfo: NORMAL_BODY"<<std::endl;
+    else if (req.getReqInfo() == ReqInfo::CHUNKED_BODY)
+        std::cout<<"ReqInfo: CHUNKED_BODY"<<std::endl;
+}
+
+int main()
+{
+    Request req_ready;
+    Request req_completed;
+    Request req_normal;
+    Request req_chunked;
+
+    req_completed.setReqInfo(ReqInfo::COMPLETE);
+    req_normal.setReqInfo(ReqInfo::NORMAL_BODY);
+    req_chunked.setReqInfo(ReqInfo::CHUNKED_BODY);
+
+    req_ready.updateReqInfo();
+    std::cout<<"Not yet requested"<<std::endl;
+    printReqInfo("", req_ready);
+    req_ready.setMethod(std::string("PUT"));
+    req_ready.setHeaders("Transfer-Encoding", "chunked");
+    std::cout<<"Now method is "<<req_ready.getMethod()<<std::endl;
+    for (auto& kv : req_ready.getHeaders())
+	{
+		std::cout << "Key: " << kv.first << " value: " << kv.second << std::endl;
+	}
+    printReqInfo("before update", req_ready); //READY
+    req_ready.updateReqInfo();
+    printReqInfo("after update", req_ready); //NORMAL_BODY
+
+    return (0);
+}


### PR DESCRIPTION
Server 클래스의 receiveRequest 함수를 대대적으로 수정하였습니다.

우선 가장 큰 변화는 로직의 구조 변화입니다.
모든 request message를 한 번에 다 읽어서 처리를 하였던 기존 방법에서
1. headers까지만 receive
2. body가 있는지, 있다면 chunked인지 normal인지 check
3. body read
위 세 가지의 구조로 작동하게 변경하였습니다.

이 과정에서 효율적인 코딩/가독성을 위하여 ReqInfo라는 enum class를 만들었으며, READY, COMPLETE, NORMAL, CHUNKED, MUST_CLEAR 다섯가지의 Type을 가지고 있습니다.

또한 Error Handling을 위한 Exception 클래스를 만들었으며, Request 객체에서의 잘못된 요청 형식에 대한 예외클래스, Server 객체에서의 Read오류와 매우 긴 Body에 대한 예외클래스를 nested 구조로 설계하였습니다.

마지막으로 매우 긴 코드를 모듈화하는 작업을 진행하여 최대한 한 가지 함수는 한 가지 기능만 할 수 있도록 맞추는 데 최선을 다했습니다. Iwoo님과 함께 switch-case, exception 등을 사용하며 이전보다는 세련된 코드가 나타날 수 있도록 해보았습니다.

더 자세한 내용은 File Changed 를 통해 확인해주세요!