### PR TITLE
Feat/server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ RM = rm -rf
 DEBUG = -D DEBUG=1
 STDOUT = -D STDOUT=1
 
-# MAIN_FILES = uri_parser_test UriParser  utils
-MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request
+# MAIN_FILES = checkAndSetLocation_test
+MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request UriParser
 
 SRCS_PATH = $(MAIN_FILES)
 VPATH := .:srcs:tests

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ RM = rm -rf
 DEBUG = -D DEBUG=1
 STDOUT = -D STDOUT=1
 
-# MAIN_FILES = checkAndSetLocation_test
+# MAIN_FILES = setRouteAndLocationInfo_test
 MAIN_FILES = logger_test Log utils ServerManager ServerGenerator Server Response Request UriParser
 
 SRCS_PATH = $(MAIN_FILES)

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -47,7 +47,7 @@ public:
     /* Exception */
     /* Util */
     // bool isLocationUri(const std::string& uri, Server* server);
-    bool checkAndSetLocation(const std::string& uri, Server* server);
+    bool setRouteAndLocationInfo(const std::string& uri, Server* server);
     bool isLimitExceptInLocation();
     bool isAllowedMethod(const std::string& method);
 

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -16,6 +16,8 @@ private:
     std::string _message_body;
     std::map<std::string, std::string> _status_code_table;
     location_info _location_info;
+    std::string _resource_abs_path;
+    std::string _route;
 
 public:
     /* Constructor */
@@ -31,13 +33,16 @@ public:
     /* Getter */
     std::string getStatusCode() const;
     std::string getStatusMessage(const std::string& code);
+    const std::string& getRoute() const;
     // std::string getHeaders() const;
     // std::string getTransferType() const;
     // std::string getClients() const;
     const location_info& getLocationInfo() const;
+    const std::string& getResourceAbsPath() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
+    void setResourceAbsPath(const std::string& path);
     // void setMessageBody();
     /* Exception */
     /* Util */

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -82,6 +82,7 @@ public:
     std::string makeResponseMessage(Request& request);
     bool sendResponse(std::string& response_meesage, int fd);
     bool isClientOfServer(int fd) const;
+    void findResourceAbsPath(int fd);
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -84,10 +84,6 @@ public:
     bool isClientOfServer(int fd) const;
 
 public:
-public:
-public:
-public:
-public:
     class PayloadTooLargeException : public std::exception
     {
     private:

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -205,7 +205,7 @@ Request::updateReqInfo()
     if (this->getMethod() == "" && this->getUri() == "" && this->getVersion() == "")
         setReqInfo(ReqInfo::READY);
     else if (this->isBodyUnnecessary())
-        setReqInfo(ReqInfo::COMPLETE);
+        setReqInfo(ReqInfo::MUST_CLEAR);
     else if (this->isNormalBody())
         setReqInfo(ReqInfo::NORMAL_BODY);
     else if (this->isChunkedBody())

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -67,6 +67,18 @@ Response::getLocationInfo() const
     return (this->_location_info);
 }
 
+const std::string&
+Response::getRoute() const
+{
+    return (this->_route);
+}
+
+const std::string&
+Response::getResourceAbsPath() const
+{
+    return (this->_resource_abs_path);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -77,6 +89,11 @@ Response::setStatusCode(const std::string& status_code)
     this->_status_code = status_code;
 }
 
+void
+Response::setResourceAbsPath(const std::string& path)
+{
+    this->_resource_abs_path = path;
+}
 /*============================================================================*/
 /******************************  Exception  ***********************************/
 /*============================================================================*/
@@ -169,30 +186,34 @@ bool
 Response::checkAndSetLocation(const std::string& uri, Server* server)
 {
     std::map<std::string, location_info> location_config = server->getLocationConfig();
-    std::string router;
+    std::string route;
 
-    if (uri[0] != '/')
-        return (false);
     if (uri.length() == 1)
     {
         if (location_config.find("/") != location_config.end())
         {
+            this->_route = uri;
             this->_location_info = location_config["/"];
             return (true);
         }
         return (false);
     }
-    size_t index = uri[uri.length() - 1] == '/' ? uri.length() : uri.length() + 1;
+    size_t index = (uri[uri.length() - 1] == '/') ? uri.length() : uri.length() + 1;
     while ((index = uri.find_last_of("/", index - 1)) != std::string::npos)
     {
-        router = uri.substr(0, index);
-        if (location_config.find(router) != location_config.end())
+        route = uri.substr(0, index);
+        if (location_config.find(route) != location_config.end())
         {
-            this->_location_info = location_config[router];
+            this->_route = route;
+            this->_location_info = location_config[route];
             return (true);
         }
         if (index == 0)
+        {
+            this->_route = "/";
+            this->_location_info = location_config["/"];
             break ;
+        }
     }
     return (false);
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -177,7 +177,7 @@ Response::applyAndCheckRequest(Request& request, Server* server)
     this->setStatusCode(request.getStatusCode());
     if (this->setRouteAndLocationInfo(request.getUri(), server))
     {
-        if (isLimitExceptInLocation() && isAllowedMethod(request.getMethod()) == false)
+        if (this->isLimitExceptInLocation() && this->isAllowedMethod(request.getMethod()) == false)
             this->setStatusCode("405");
     }
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -175,7 +175,7 @@ void
 Response::applyAndCheckRequest(Request& request, Server* server)
 {
     this->setStatusCode(request.getStatusCode());
-    if (checkAndSetLocation(request.getUri(), server))
+    if (this->setRouteAndLocationInfo(request.getUri(), server))
     {
         if (isLimitExceptInLocation() && isAllowedMethod(request.getMethod()) == false)
             this->setStatusCode("405");
@@ -183,7 +183,7 @@ Response::applyAndCheckRequest(Request& request, Server* server)
 }
 
 bool
-Response::checkAndSetLocation(const std::string& uri, Server* server)
+Response::setRouteAndLocationInfo(const std::string& uri, Server* server)
 {
     std::map<std::string, location_info> location_config = server->getLocationConfig();
     std::string route;

--- a/srcs/UriParser.cpp
+++ b/srcs/UriParser.cpp
@@ -155,14 +155,13 @@ UriParser::parseUri(const std::string& uri)
     {
         this->setPath("/");
         this->setPaths();
-        this->print();
     }
     else
     {
         this->setPath(this->findPath());
         this->setPaths();
-        this->print();
     }
+    // this->_path.insert(this->_path.begin(), '/');
 }
 
 std::string
@@ -187,7 +186,8 @@ UriParser::findHostAndPort()
 
     if (this->_uri[this->_index] == '/')
     {
-        this->setIndex(this->_index + 1);
+        // this->setIndex(this->_index + 1); // NOTE
+        this->setIndex(this->_index); // NOTE
         return ("");
     }
     found = this->_uri.find("/", this->_index);
@@ -196,7 +196,8 @@ UriParser::findHostAndPort()
         this->setIndex(found);
         return (this->_uri.substr(temp_index));
     }
-    this->setIndex(found + 1);
+    // this->setIndex(found + 1); // NOTE
+    this->setIndex(found); // NOTE
     return (this->_uri.substr(temp_index, found - temp_index));
 }
 

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -1,9 +1,19 @@
 http { 
     include mime.types;
-    root /test/folder;
+    root /555/444/;
     server {
         server_name first_server;
         listen       8080;
+
+        location /folder {
+            root /111/;
+        }
+        location /folder/folder {
+            root /222/111/;
+        }
+        location /folder/folder/folder {
+            root /333/222/111/;
+        }
     }
     server {
         server_name second_server;

--- a/tests/setRouteAndLocationInfo_test.cpp
+++ b/tests/setRouteAndLocationInfo_test.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <string>
 
-bool checkAndSetLocation(const std::string &uri)
+bool setRouteAndLocationInfo(const std::string &uri)
 {
 
     std::map<std::string, std::string> one = { {"root", "/user/iwoo"}, {"index", "html;"}, {"limit_except", "PUT"} };
@@ -59,31 +59,31 @@ int main()
 
     std::cout<<"==================="<<std::endl;
     std::cout <<"Case: " << uri1 <<std::endl;
-    ret = checkAndSetLocation(uri1);
+    ret = setRouteAndLocationInfo(uri1);
     std::cout<<"--> Result1: " << ret << std::endl;
 
     std::cout<<"==================="<<std::endl;
     std::cout <<"Case: " << uri2 << std::endl;
-    ret = checkAndSetLocation(uri2);
+    ret = setRouteAndLocationInfo(uri2);
     std::cout<<"--> Result2: " << ret << std::endl;
 
     std::cout<<"==================="<<std::endl;
     std::cout <<"Case: " << uri3 << std::endl;
-    ret = checkAndSetLocation(uri3);
+    ret = setRouteAndLocationInfo(uri3);
     std::cout <<"--> Result3: " << ret << std::endl;
 
     std::cout<<"==================="<<std::endl;
     std::cout <<"Case: " << uri4 << std::endl;
-    ret = checkAndSetLocation(uri4);
+    ret = setRouteAndLocationInfo(uri4);
     std::cout <<"--> Result4: " << ret << std::endl;
 
     std::cout<<"==================="<<std::endl;
     std::cout <<"Case: " << uri5 << std::endl;
-    ret = checkAndSetLocation(uri5);
+    ret = setRouteAndLocationInfo(uri5);
     std::cout <<"--> Result5: " << ret << std::endl;
 
     std::cout<<"==================="<<std::endl;
     std::cout <<"Case: " << uri6 << std::endl;
-    ret = checkAndSetLocation(uri6);
+    ret = setRouteAndLocationInfo(uri6);
     std::cout <<"--> Result6: " << ret << std::endl;
 }


### PR DESCRIPTION
### ReqInfo::COMPLETE 조건 변경
  - Client로부터의 요청을 수신하고, 수신한 모든 buffer를 비운 경우에만 `ReqInfo::COMPLETE` 상태가 되도록 수정되었습니다. 

### checkAndSetLocation --> setRouteAndLocationInfo 로 함수명을 변경했습니다.
  - 이유) checkAndSetLocation의 역할이 Response 객체의 `_route`와  `_location_info`를 저장하는 역할로 변경되었기 때문입니다.


### findResourceAbsPath 함수를 추가하였습니다.
  - 역할) 이 함수는 요청된 자원의 주소를 절대주소를 확인하여 Response 객체에 `_resource_abs_file` 멤버변수에 저장합니다.
  - 동작예시1) 아래 조건일 경우: **_resource_abs_file == '/root/var/file'**
     - 요청URI: 'POST /folder/file HTTP/1.1'
     - Location route: '/folder/`
     - Location root: '/root/var/'

  - 동작예시2) 아래 조건일 경우: **_resource_abs_file == '/root/var/folder/'**
     - 요청URI: 'POST /folder/folder/ HTTP/1.1'
     - Location route: '/folder/`
     - Location root: '/root/var/'

  - 동작예시3) 아래 조건일 경우: **_resource_abs_file == '/root/default/'**
     - 요청URI: 'POST / HTTP/1.1'
     - Location route: '/folder/`
     - Location root: '/root/var/'
     - default root: '/root/default/'

  - 동작예시4) 아래 조건일 경우: **_resource_abs_file == '/root/default/file'**
     - 요청URI: 'POST /file HTTP/1.1'
     - Location route: '/folder/`
     - Location root: '/root/var/'
     - default root: '/root/default/'