### PR TITLE
Feat/server open static resource exception

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -41,11 +41,12 @@ public:
     // std::string getClients() const;
     const location_info& getLocationInfo() const;
     const std::string& getResourceAbsPath() const;
-    struct stat getFileInfo() const;
+    const struct stat& getFileInfo() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
     void setResourceAbsPath(const std::string& path);
+    void setFileInfo(const struct stat& file_info);
     // void setMessageBody();
     /* Exception */
     /* Util */

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -3,6 +3,7 @@
 
 # include "Request.hpp"
 # include "types.hpp"
+# include <sys/stat.h>
 
 class Server;
 
@@ -18,6 +19,7 @@ private:
     location_info _location_info;
     std::string _resource_abs_path;
     std::string _route;
+    struct stat _file_info;
 
 public:
     /* Constructor */
@@ -39,6 +41,7 @@ public:
     // std::string getClients() const;
     const location_info& getLocationInfo() const;
     const std::string& getResourceAbsPath() const;
+    struct stat getFileInfo() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -12,6 +12,7 @@
 # include <algorithm>
 # include <vector>
 # include <fcntl.h>
+# include <errno.h>
 # include "types.hpp"
 # include "Request.hpp"
 # include "Response.hpp"
@@ -98,6 +99,16 @@ public:
     {
     public:
         virtual const char* what() const throw();
+    };
+    class OpenResourceErrorException : public std::exception
+    {
+    private:
+        Response& _response;
+        int _error;
+        char* _str_error;
+    public:
+        OpenResourceErrorException(Response& response, int error, char* str_error);
+        std::string s_what() const throw();
     };
 
 // public:

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -105,9 +105,8 @@ public:
     private:
         Response& _response;
         int _error;
-        char* _str_error;
     public:
-        OpenResourceErrorException(Response& response, int error, char* str_error);
+        OpenResourceErrorException(Response& response, int error);
         std::string s_what() const throw();
     };
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -13,6 +13,7 @@ Response::Response()
 : _status_code(""), _transfer_type(""), _clients(""), _message_body("")
 {
     this->_headers = { {"", ""} };
+    ft::memset(&this->_file_info, 0, sizeof(this->_file_info));
     this->initStatusCodeTable();
 }
 
@@ -79,7 +80,7 @@ Response::getResourceAbsPath() const
     return (this->_resource_abs_path);
 }
 
-struct stat
+const struct stat&
 Response::getFileInfo() const
 {
     return (this->_file_info);
@@ -100,6 +101,13 @@ Response::setResourceAbsPath(const std::string& path)
 {
     this->_resource_abs_path = path;
 }
+
+void
+Response::setFileInfo(const struct stat& file_info)
+{
+    this->_file_info = file_info;
+}
+
 /*============================================================================*/
 /******************************  Exception  ***********************************/
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -10,7 +10,7 @@
 /*============================================================================*/
 
 Response::Response()
-: _status_code(""), _transfer_type(""), _clients(""), _message_body("") 
+: _status_code(""), _transfer_type(""), _clients(""), _message_body("")
 {
     this->_headers = { {"", ""} };
     this->initStatusCodeTable();
@@ -77,6 +77,12 @@ const std::string&
 Response::getResourceAbsPath() const
 {
     return (this->_resource_abs_path);
+}
+
+struct stat
+Response::getFileInfo() const
+{
+    return (this->_file_info);
 }
 
 /*============================================================================*/

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -58,8 +58,6 @@ Server::getServerSocket() const
     return (this->_server_socket);
 }
 
-
-
 const std::map<std::string, location_info>&
 Server::getLocationConfig()
 {
@@ -101,6 +99,29 @@ const char*
 Server::ReadErrorException::what() const throw()
 {
     return ("[CODE 900] Read empty buffer or occured reading error");
+}
+
+Server::OpenResourceErrorException::OpenResourceErrorException(Response& response, int error, char* str_error)
+: _response(response), _error(error), _str_error(str_error)
+{
+    if (this->_error == EACCES)
+        this->_response.setStatusCode("403");
+    else
+        this->_response.setStatusCode("404");
+}
+
+std::string
+Server::OpenResourceErrorException::s_what() const throw()
+{
+    std::string msg;
+    const std::string& code = this->_response.getStatusCode();
+
+    msg += "[CODE ";
+    msg += code;
+    msg += "] ";
+    (code.compare("404") == 0) ? msg += "Not Found: " : msg +="Forbidden: ";
+    msg += this->_str_error;
+    return (msg);
 }
 
 /*============================================================================*/
@@ -366,6 +387,7 @@ Server::openStaticResource(int fd)
 {
     int resource_fd;
     const std::string& path = this->_responses[fd].getResourceAbsPath();
+    struct stat tmp = this->_responses[fd].getFileInfo();
 
     if ((resource_fd = open(path.c_str(), O_RDWR, 0644)) > 0)
     {
@@ -373,9 +395,11 @@ Server::openStaticResource(int fd)
         this->_server_manager->fdSet(resource_fd, FdSet::READ);
         this->_server_manager->setResourceOnFdTable(resource_fd, fd);
         this->_server_manager->updateFdMax(resource_fd);
+        if ((fstat(resource_fd, &tmp)) == -1)
+            throw strerror(errno);
     }
     else
-        throw "File cannot open";
+        throw OpenResourceErrorException(this->_responses[fd], errno, strerror(errno));
 }
 
 void
@@ -452,6 +476,11 @@ Server::run(int fd)
             {
                 this->closeClientSocket(fd);
                 std::cerr << e.what() << '\n';
+            }
+            catch(const OpenResourceErrorException& e)
+            {
+                this->_server_manager->fdSet(fd, FdSet::WRITE);
+                std::cerr << e.s_what() << '\n';
             }
             catch(const std::exception& e)
             {

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -1,6 +1,6 @@
 http { 
     include mime.types;
-    root /Users/yohlee/goinfre/123/tests/;
+    root /Users/yohlee/Webserv/tests/;
     server {
         server_name first_server;
         listen       8080;


### PR DESCRIPTION
Static Resource File Open 실패 시 예외처리를 할 수 있도록 하는 예외중첩클래스를 만들었습니다.

errno에 따라 적절한 상태 코드와 메세지를 리턴하게 되며,

file open이 성공적으로 끝나면 response 객체의 file_info 구조체에 fstat 값을 세팅하도록 했습니다.

이 구조체들은 추후
- Last-Modified
- Content-Length
위 두개의 헤더를 처리하는 데 사용될 예정입니다.

## open 성공 시
![image](https://user-images.githubusercontent.com/49181231/97662276-e8169c80-1ab9-11eb-8228-69ef483d91a4.png)

## open 실패 + 파일을 찾지 못했을 경우
![image](https://user-images.githubusercontent.com/49181231/97662280-eb118d00-1ab9-11eb-8a40-ce51418421f3.png)

## open 실패 + 파일의 권한이 없는 경우
![image](https://user-images.githubusercontent.com/49181231/97662286-ecdb5080-1ab9-11eb-8811-750fceb730f2.png)
