### PR TITLE
Refactor/server run

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -22,6 +22,7 @@ private:
     std::string _route;
     std::string _directory_entry;
     struct stat _file_info;
+    ResType _resource_type;
 
 public:
     /* Constructor */
@@ -45,12 +46,14 @@ public:
     const std::string& getResourceAbsPath() const;
     const std::string& getDirectoryEntry() const;
     const struct stat& getFileInfo() const;
+    const ResType& getResourceType() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
     void setResourceAbsPath(const std::string& path);
     void setDirectoryEntry(DIR* dir_ptr);
     void setFileInfo(const struct stat& file_info);
+    void setResourceType(const ResType& resource_type);
     // void setMessageBody();
     /* Exception */
     /* Util */

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -123,11 +123,11 @@ public:
     class CannotOpenDirectoryException : public SendErrorCodeToClientException
     {
     private:
-        Request& _req;
+        Response& _res;
         int _error_num;
         std::string _msg;
     public:
-        CannotOpenDirectoryException(Request& req, const std::string& status_code, int error_num);
+        CannotOpenDirectoryException(Response& res, const std::string& status_code, int error_num);
         virtual const char* what() const throw();
     };
     class IndexNoExistException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -134,6 +134,14 @@ public:
         OpenResourceErrorException(Response& response, int error_num);
         virtual const char* what() const throw();
     };
+    class IndexNoExistException : public std::exception
+    {
+    private:
+        Response& _response;
+    public:
+        IndexNoExistException(Response& response);
+        virtual const char* what() const throw();
+    };
 
 
 // public:

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -89,8 +89,9 @@ public:
     void findResourceAbsPath(int fd);
     bool isAutoIndexOn(int fd);
     bool isCgiUri(int fd);
-    ResType checkResourceType(int fd);
+    void checkResourceType(int fd);
     void openStaticResource(int fd);
+    void setResourceAbsPathAsIndex(int fd);
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -118,21 +118,20 @@ public:
     {
     private:
         Request& _req;
-        int _error;
+        int _error_num;
         std::string _msg;
     public:
         CannotOpenDirectoryException(Request& req, const std::string& status_code, int error_num);
-        CannotOpenDirectoryException(Request& req);
         virtual const char* what() const throw();
     };
     class OpenResourceErrorException : public std::exception
     {
     private:
         Response& _response;
-        int _error;
+        int _error_num;
         std::string _msg;
     public:
-        OpenResourceErrorException(Response& response, int error);
+        OpenResourceErrorException(Response& response, int error_num);
         virtual const char* what() const throw();
     };
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -91,7 +91,7 @@ public:
     void findResourceAbsPath(int fd);
     bool isAutoIndexOn(int fd);
     bool isCgiUri(int fd);
-    void checkResourceType(int fd);
+    void checkAndSetResourceType(int fd);
     void openStaticResource(int fd);
     void setResourceAbsPathAsIndex(int fd);
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -63,7 +63,9 @@ public:
     Request& getRequest(int fd);
     /* Setter */
     void setServerSocket();
+
     /* Exception */
+
     /* Util */
     bool closeClientSocket(int fd);
     bool isFdManagedByServer(int fd) const;
@@ -92,6 +94,10 @@ public:
     void checkResourceType(int fd);
     void openStaticResource(int fd);
     void setResourceAbsPathAsIndex(int fd);
+
+    /* Server run function */
+    void acceptClient();
+    
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -118,20 +118,24 @@ public:
     {
     private:
         Request& _req;
+        int _error;
+        std::string _msg;
     public:
-        CannotOpenDirectoryException(Request& req, const std::string& status_code);
+        CannotOpenDirectoryException(Request& req, const std::string& status_code, int error_num);
         CannotOpenDirectoryException(Request& req);
-        virtual std::string s_what() const throw();
+        virtual const char* what() const throw();
     };
     class OpenResourceErrorException : public std::exception
     {
     private:
         Response& _response;
         int _error;
+        std::string _msg;
     public:
         OpenResourceErrorException(Response& response, int error);
-        std::string s_what() const throw();
+        virtual const char* what() const throw();
     };
+
 
 // public:
 //     class ResponseException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -114,7 +114,13 @@ public:
         virtual const char* what() const throw();
     };
 public:
-    class CannotOpenDirectoryException : public std::exception
+    class SendErrorCodeToClientException : public std::exception
+    {
+    public:
+        SendErrorCodeToClientException();
+        virtual const char* what() const throw();
+    };
+    class CannotOpenDirectoryException : public SendErrorCodeToClientException
     {
     private:
         Request& _req;
@@ -122,6 +128,14 @@ public:
         std::string _msg;
     public:
         CannotOpenDirectoryException(Request& req, const std::string& status_code, int error_num);
+        virtual const char* what() const throw();
+    };
+    class IndexNoExistException : public SendErrorCodeToClientException
+    {
+    private:
+        Response& _response;
+    public:
+        IndexNoExistException(Response& response);
         virtual const char* what() const throw();
     };
     class OpenResourceErrorException : public std::exception
@@ -134,22 +148,6 @@ public:
         OpenResourceErrorException(Response& response, int error_num);
         virtual const char* what() const throw();
     };
-    class IndexNoExistException : public std::exception
-    {
-    private:
-        Response& _response;
-    public:
-        IndexNoExistException(Response& response);
-        virtual const char* what() const throw();
-    };
-
-
-// public:
-//     class ResponseException : public std::exception
-//     {
-//     public:
-//         virtual const char* what() const throw();
-//     };
 };
 
 #endif

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -72,8 +72,7 @@ enum class ResType
     STATIC_RESOURCE,
     CGI,
     AUTO_INDEX,
-    INDEX_HTML,
-    ERROR_CODE
+    INDEX_HTML
 };
 
 #endif

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -92,6 +92,12 @@ Response::getFileInfo() const
     return (this->_file_info);
 }
 
+const ResType&
+Response::getResourceType() const
+{
+    return (this->_resource_type);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -123,6 +129,12 @@ void
 Response::setFileInfo(const struct stat& file_info)
 {
     this->_file_info = file_info;
+}
+
+void
+Response::setResourceType(const ResType& resource_type)
+{
+    this->_resource_type = resource_type;
 }
 
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -219,6 +219,7 @@ Response::initStatusCodeTable()
     };
 }
 
+//TODO: Response에 상태코드 세팅하게 변경하기.
 void
 Response::applyAndCheckRequest(Request& request, Server* server)
 {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -125,10 +125,10 @@ Server::ReadErrorException::what() const throw()
     return ("[CODE 900] Read empty buffer or occured reading error");
 }
 
-Server::CannotOpenDirectoryException::CannotOpenDirectoryException(Request& req, const std::string& status_code, int error_num)
-: _req(req), _error_num(error_num), _msg("CannotOpenDirectoryException: " + std::string(strerror(_error_num)))
+Server::CannotOpenDirectoryException::CannotOpenDirectoryException(Response& res, const std::string& status_code, int error_num)
+: _res(res), _error_num(error_num), _msg("CannotOpenDirectoryException: " + std::string(strerror(_error_num)))
 {
-    this->_req.setStatusCode(status_code);
+    this->_res.setStatusCode(status_code);
 }
 
 const char*
@@ -650,9 +650,9 @@ Server::checkAndSetResourceType(int fd)
         if (errno == ENOTDIR)
             response.setResourceType(ResType::STATIC_RESOURCE);
         else if (errno == EACCES)
-            throw (CannotOpenDirectoryException(this->_requests[fd], "403", errno));
+            throw (CannotOpenDirectoryException(this->_responses[fd], "403", errno));
         else if (errno == ENOENT)
-            throw (CannotOpenDirectoryException(this->_requests[fd], "404", errno));
+            throw (CannotOpenDirectoryException(this->_responses[fd], "404", errno));
     }
     else
     {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -121,23 +121,17 @@ Server::ReadErrorException::what() const throw()
 }
 
 Server::CannotOpenDirectoryException::CannotOpenDirectoryException(Request& req, const std::string& status_code, int error_num)
-: _req(req), _error(error_num), _msg("CannotOpenDirectoryException: " + std::string(strerror(_error)))
+: _req(req), _error_num(error_num), _msg("CannotOpenDirectoryException: " + std::string(strerror(_error_num)))
 {
     req.setStatusCode(status_code);
 }
 
-const char*
-Server::CannotOpenDirectoryException::what() const throw()
-{
-    return (this->_msg.c_str());
-}
-
 Server::OpenResourceErrorException::OpenResourceErrorException(Response& response, int error)
-: _response(response), _error(error), _msg("OpenResourceErrorException: " + std::string(strerror(this->_error)))
+: _response(response), _error_num(error), _msg("OpenResourceErrorException: " + std::string(strerror(this->_error_num)))
 {
-    if (this->_error == EACCES)
+    if (this->_error_num == EACCES)
         this->_response.setStatusCode("403");
-    else if (this->_error == ENOMEM)
+    else if (this->_error_num == ENOMEM)
         this->_response.setStatusCode("500");
     else
         this->_response.setStatusCode("404");

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -123,7 +123,13 @@ Server::ReadErrorException::what() const throw()
 Server::CannotOpenDirectoryException::CannotOpenDirectoryException(Request& req, const std::string& status_code, int error_num)
 : _req(req), _error_num(error_num), _msg("CannotOpenDirectoryException: " + std::string(strerror(_error_num)))
 {
-    req.setStatusCode(status_code);
+    this->_req.setStatusCode(status_code);
+}
+
+const char*
+Server::CannotOpenDirectoryException::what() const throw()
+{
+    return (this->_msg.c_str());
 }
 
 Server::OpenResourceErrorException::OpenResourceErrorException(Response& response, int error)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -91,7 +91,10 @@ Server::setResourceAbsPathAsIndex(int fd)
     for (std::string& index : indexs)
     {
         if (dir_entry.find(index) != std::string::npos)
+        {
+            response.setResourceType(ResType::STATIC_RESOURCE);
             response.setResourceAbsPath(path + index);
+        }
     }
 }
 
@@ -518,35 +521,28 @@ Server::run(int fd)
                     this->receiveRequest(fd);
                     if (this->_requests[fd].getReqInfo() == ReqInfo::COMPLETE)
                     {
+                        //processingResponseBody()
                         this->findResourceAbsPath(fd);
                         this->checkResourceType(fd);
-                        // 1.index -> static // fileAbsPath -> 
-
+                        if (this->_responses[fd].getResourceType() == ResType::INDEX_HTML)
+                            this->setResourceAbsPathAsIndex(fd);
                         ResType res_type = this->_responses[fd].getResourceType();
                         switch (res_type)
                         {
-                        case ResType::INDEX_HTML:
-                            this->setResourceAbsPathAsIndex(fd);
-                            break ;
                         case ResType::AUTO_INDEX:
-                            
+                            std::cout << "auto index" << std::endl;
                             break ;
                         case ResType::STATIC_RESOURCE:
+                            std::cout << "static file path" << std::endl;
                             this->openStaticResource(fd);
                             break ;
                         case ResType::CGI:
-                            
+                            std::cout << "cgi" << std::endl;
                             break ;
                         default:
-                            
+                            std::cout << "Whatwhahahahha" << std::endl;
                             break ;
                         }
-
-                        // 2. autoindex
-                        // 3. static -> open
-                        // 4. cgi
-                        this->openStaticResource(fd);
-                        // preprocessing with swith of res;
                     }
                     Log::getRequest(*this, fd);
                 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -525,7 +525,7 @@ Server::run(int fd)
                     {
                         //processingResponseBody()
                         this->findResourceAbsPath(fd);
-                        this->checkResourceType(fd);
+                        this->checkAndSetResourceType(fd);
                         if (this->_responses[fd].getResourceType() == ResType::INDEX_HTML)
                             this->setResourceAbsPathAsIndex(fd);
                         ResType res_type = this->_responses[fd].getResourceType();
@@ -632,7 +632,7 @@ Server::isCgiUri(int fd)
 }
 
 void
-Server::checkResourceType(int fd)
+Server::checkAndSetResourceType(int fd)
 {
     Response& response = this->_responses[fd];
     if (this->isCgiUri(fd))

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -7,7 +7,7 @@ http {
 
         location /folder {
             cgi .bin .cgi .bla;
-            autoindex off;
+            autoindex on;
             root /goinfre/iwoo/;
         }
     }

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -7,8 +7,8 @@ http {
 
         location /folder {
             cgi .bin .cgi .bla;
-            autoindex on;
-            root /goinfre/iwoo/;
+            autoindex off;
+            root /goinfre/yohlee/;
         }
     }
     server {


### PR DESCRIPTION
특수한 동작을 요구하는 예외클래스들을 제외하고 Catch 시 동작이 같은 예외클래스들을 공통으로 처리했습니다.

또한 run 함수 내부에서 fd가 서버소켓일 때 클라이언트를 accept 하는  acceptClient 함수를 만들어서 라인을 줄여보았습니다.