### PR TITLE
Refactor/server processing response body

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -94,6 +94,8 @@ public:
     void checkAndSetResourceType(int fd);
     void openStaticResource(int fd);
     void setResourceAbsPathAsIndex(int fd);
+    void processResponseBody(int fd);
+    void preprocessResponseBody(int fd, ResType& res_type);
 
     /* Server run function */
     void acceptClient();

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -547,7 +547,7 @@ Server::run(int fd)
                     this->_requests[fd].setReqInfo(ReqInfo::COMPLETE);
                     this->_server_manager->fdSet(fd, FdSet::WRITE);
                 }
-                //TODO: status code값이 세팅된 경우 response에 채워주기.
+                this->_responses[fd].setStatusCode(this->_requests[fd].getStatusCode());
             }
             catch(const std::exception& e)
             {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -529,30 +529,7 @@ Server::run(int fd)
                 {
                     this->receiveRequest(fd);
                     if (this->_requests[fd].getReqInfo() == ReqInfo::COMPLETE)
-                    {
-                        //processingResponseBody()
-                        this->findResourceAbsPath(fd);
-                        this->checkAndSetResourceType(fd);
-                        if (this->_responses[fd].getResourceType() == ResType::INDEX_HTML)
-                            this->setResourceAbsPathAsIndex(fd);
-                        ResType res_type = this->_responses[fd].getResourceType();
-                        switch (res_type)
-                        {
-                        case ResType::AUTO_INDEX:
-                            std::cout << "auto index" << std::endl;
-                            break ;
-                        case ResType::STATIC_RESOURCE:
-                            std::cout << "static file path" << std::endl;
-                            this->openStaticResource(fd);
-                            break ;
-                        case ResType::CGI:
-                            std::cout << "cgi" << std::endl;
-                            break ;
-                        default:
-                            std::cout << "Whatwhahahahha" << std::endl;
-                            break ;
-                        }
-                    }
+                        processResponseBody(fd);
                     Log::getRequest(*this, fd);
                 }
             }
@@ -668,4 +645,35 @@ Server::checkAndSetResourceType(int fd)
                 throw (IndexNoExistException(this->_responses[fd]));
         }
     }
+}
+
+void
+Server::preprocessResponseBody(int fd, ResType& res_type)
+{
+    switch (res_type)
+    {
+    case ResType::AUTO_INDEX:
+        std::cout << "auto index" << std::endl;
+        break ;
+    case ResType::STATIC_RESOURCE:
+        std::cout << "static file path" << std::endl;
+        this->openStaticResource(fd);
+        break ;
+    case ResType::CGI:
+        std::cout << "cgi" << std::endl;
+        break ;
+    default:
+        break ;
+    }
+}
+
+void
+Server::processResponseBody(int fd)
+{
+    this->findResourceAbsPath(fd);
+    this->checkAndSetResourceType(fd);
+    if (this->_responses[fd].getResourceType() == ResType::INDEX_HTML)
+        this->setResourceAbsPathAsIndex(fd);
+    ResType res_type = this->_responses[fd].getResourceType();
+    preprocessResponseBody(fd, res_type);
 }

--- a/tests/config_testfile
+++ b/tests/config_testfile
@@ -1,6 +1,6 @@
 http { 
     include mime.types;
-    root /Users/yohlee/Webserv/tests/;
+    root /Users/iwoo/Documents/Webserv
     server {
         server_name first_server;
         listen       8080;
@@ -8,7 +8,7 @@ http {
         location /folder {
             cgi .bin .cgi .bla;
             autoindex off;
-            root /goinfre/yohlee/;
+            root /goinfre/iwoo/;
         }
     }
     server {


### PR DESCRIPTION
server run 함수가 너무 비대해져서 리팩토링했습니다. 내용은 아래와 같습니다.

1. `Server::run`함수 내에서 client로부터의 요청을 모두 받은 후에 그 요청이 어떤 자원을 요구하는지, 에러는 없는지 확인하는 작업을 `processResponseBody` 함수로 묶어서 모듈화했습니다.
2. 또한 `processResponseBody` 함수 내에서 요구된 자원의 성격에 따라 파일 open, pipe open 등의 처리흐름을 분기시키는 구문을 묶어서 `preprocessResponseBody` 함수로 만들었습니다.
3. ReqeustFormatException이 던져지면 기존에는 Request 객체의 status_code만 변경했었지만, Reponse 객체의 status_code도 추가로 변경하도록 수정했습니다.