### PR TITLE
FIX: error when deal with empty body request

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -202,6 +202,8 @@ std::ostream& operator<< (std::ostream& out, Request& object)
 void
 Request::updateReqInfo()
 {
+    if (this->getReqInfo() == ReqInfo::COMPLETE)
+        return ;
     if (this->getMethod() == "" && this->getUri() == "" && this->getVersion() == "")
         setReqInfo(ReqInfo::READY);
     else if (this->isBodyUnnecessary())
@@ -216,7 +218,7 @@ bool
 Request::isBodyUnnecessary() const
 {
     const std::string& method = this->getMethod();
-    if (method.compare("PUT") || method.compare("POST"))
+    if (method.compare("PUT") == 0 || method.compare("POST") == 0)
         return (false);
     return (true);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -230,12 +230,16 @@ Server::receiveRequestWithoutBody(int fd)
     size_t header_end_pos = 0;
     Request& req = this->_requests[fd];
 
+    ft::memset(reinterpret_cast<void *>(buf), 0, BUFFER_SIZE + 1);
     if ((bytes = recv(fd, buf, BUFFER_SIZE, MSG_PEEK)) > 0)
     {
         if ((header_end_pos = std::string(buf).find("\r\n\r\n")) != std::string::npos)
         {
             if (static_cast<size_t>(bytes) == header_end_pos + 4)
+            {
                 req.setIsBufferLeft(false);
+                req.setReqInfo(ReqInfo::COMPLETE);
+            }
             else
                 req.setIsBufferLeft(true);
             this->readBufferUntilHeaders(fd, buf, header_end_pos);
@@ -554,6 +558,11 @@ Server::run(int fd)
                         }
                     }
                     Log::getRequest(*this, fd);
+                    std::cout<<"Server::run: fd:"<<fd<<std::endl;
+                    if (this->_server_manager->fdIsSet(fd, FdSet::READ))
+                    {
+                        std::cout<<"fd "<<fd<<" is set now"<<std::endl;
+                    }
                 }
             }
             catch(const SendErrorCodeToClientException& e)
@@ -563,6 +572,7 @@ Server::run(int fd)
             }
             catch(const Request::RequestFormatException& e)
             {
+                std::cout<<"RequestFormatException."<<std::endl;
                 if (this->_requests[fd].isContentLeftInBuffer())
                     this->_requests[fd].setReqInfo(ReqInfo::MUST_CLEAR);
                 else

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -243,9 +243,8 @@ ServerManager::runServers()
         this->_copy_readfds = this->_readfds;
         this->_copy_writefds = this->_writefds;
         this->_copy_exceptfds = this->_exceptfds;
-        if ((selected_fds = select(this->getFdMax() + 1,
-             &this->_copy_readfds, &this->_copy_writefds,
-             &this->_copy_exceptfds, &timeout)) == -1)
+        if ((selected_fds = select(this->getFdMax() + 1, &this->_copy_readfds, 
+            &this->_copy_writefds, &this->_copy_exceptfds, &timeout)) == -1)
         {
             std::cerr<<"Error : select"<<std::endl;
             return (false);
@@ -263,7 +262,6 @@ ServerManager::runServers()
                 {
                     for (Server *server : this->_servers)
                     {
-                        // if (fd == server->getServerSocket() || server->isClientOfServer(fd))
                         if (fd == server->getServerSocket() || server->isFdManagedByServer(fd))
                             server->run(fd);
                     }


### PR DESCRIPTION
Request에 body가 존재하지 않으면  write_fdset이 셋팅되지 않는 문제점이 있었습니다.
원인은 아래와 같았습니다.
 1. 만약 body가 필요하지 않다면, buffer를 모두 비운 후 write_set을 셋팅하는 흐름을 가지고 있었음.
 2. 그러나 이는 select 하기 전에 buffer가 비어있다면 select함수가 read_fdset을 비우기에 write_set을 셋팅하기 전에 read_set이 초기화되어, 결과적으로 wrtie_set이 영원히 셋팅되지 않는 다는 것을 간과했기 때문임.

따라서 만약 Request body를 읽을 필요가 없고, client socket buffer에 더 이상의 Request body가 없을 경우, 바로 write_fd set을 셋팅해주도록 변경하여 에러수정하였습니다.

그 외에 isUnnecessaryBody 함수의 조건문에 오류가 있었던 점, recv하는 시점에 buf가 memset 되지 않은 점을 확인하여 sanam, yohai님이 수정해주셨습니다.