### PR TITLE
Fix/autoindex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ INCLUDES = -I include
 CC = clang++
 CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
-DEBUG = -D DEBUG=1
+# 1 일 때 디폴트 에러 로그, 2일 때 trace로그 추가
+DEBUG = -D DEBUG=2
 STDOUT = -D STDOUT=1
 
 # MAIN_FILES = setRouteAndLocationInfo_test

--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -29,6 +29,9 @@ public:
     // static void notAllowedMethod(Server& server);
     // static void fileNotfound();
 
+    // trace
+    static void trace(const std::string& message);
+
 };
 
 #endif

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -140,3 +140,17 @@ Log::error(const std::string& error)
     Log::timeLog(fd);
     write(fd, error.c_str(), error.length());
 }
+
+void
+Log::trace(const std::string& trace)
+{
+    if (DEBUG != 2)
+        return ;
+
+    std::string line;
+    int fd = (STDOUT == 1) ? 1 : Log::access_fd;
+
+    Log::timeLog(fd);
+    write(fd, trace.c_str(), trace.length());
+    write(fd, "\n", 1);
+}

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -1,4 +1,5 @@
 #include "Request.hpp"
+#include "Log.hpp"
 
 /*============================================================================*/
 /****************************  Static variables  ******************************/
@@ -202,6 +203,7 @@ std::ostream& operator<< (std::ostream& out, Request& object)
 void
 Request::updateReqInfo()
 {
+    Log::trace("> updateReqInfo");
     if (this->getReqInfo() == ReqInfo::COMPLETE)
         return ;
     if (this->getMethod() == "" && this->getUri() == "" && this->getVersion() == "")
@@ -212,6 +214,7 @@ Request::updateReqInfo()
         setReqInfo(ReqInfo::NORMAL_BODY);
     else if (this->isChunkedBody())
         setReqInfo(ReqInfo::CHUNKED_BODY);
+    Log::trace("< updateReqInfo");
 }
 
 bool
@@ -260,6 +263,7 @@ Request::updateStatusCodeAndReturn(const std::string& status_code, const bool& r
 void
 Request::parseRequestWithoutBody(char* buf)
 {
+    Log::trace("> parseRequestWithoutBody");
     std::string line;
     std::string req_message(buf);
 
@@ -278,11 +282,13 @@ Request::parseRequestWithoutBody(char* buf)
             throw (RequestFormatException(*this));
     }
     this->updateReqInfo();
+    Log::trace("< parseRequestWithoutBody");
 }
 
 bool
 Request::parseRequestLine(std::string& req_message)
 {
+    Log::trace("> parseRequestLine");
     std::vector<std::string> request_line = ft::split(req_message, " ");
     
     if (isValidLine(request_line) == false)
@@ -290,12 +296,14 @@ Request::parseRequestLine(std::string& req_message)
     this->setMethod(request_line[0]);
     this->setUri(request_line[1]);
     this->setVersion(request_line[2]);
+    Log::trace("< parseRequestLine");
     return (true);
 }
 
 bool
 Request::parseHeaders(std::string& req_message)
 {
+    Log::trace("> parseHeaders");
     std::string key;
     std::string value;
     std::string line;
@@ -315,6 +323,7 @@ Request::parseHeaders(std::string& req_message)
     if (this->isValidHeaders(key, value) == false)
         return (updateStatusCodeAndReturn("400", false));
     this->setHeaders(key, value);
+    Log::trace("< parseHeaders");
     return (true);
 }
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -176,7 +176,6 @@ Request::RequestFormatException::s_what() const throw()
     std::string tmp;
     tmp += this->_msg;
     tmp += this->_req.getStatusCode();
-    std::cout<<"in reqformat except: "<<tmp<<std::endl;
     return (tmp);
 }
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1,6 +1,7 @@
 #include "Response.hpp"
 #include "Server.hpp"
 #include "PageGenerator.hpp"
+#include "Log.hpp"
 
 /*============================================================================*/
 /****************************  Static variables  ******************************/
@@ -236,7 +237,6 @@ Response::initStatusCodeTable()
 void
 Response::applyAndCheckRequest(Request& request, Server* server)
 {
-    this->setStatusCode(request.getStatusCode());
     if (this->setRouteAndLocationInfo(request.getUri(), server))
     {
         if (this->isLimitExceptInLocation() && this->isAllowedMethod(request.getMethod()) == false)
@@ -307,13 +307,23 @@ void
 Response::makeBody(Request& request)
 {
     // std::string body;
+    Log::error("in makeBody\n");
+    std::cout<<request<<std::endl;
+    std::cout<<"=================="<<std::endl;
     (void)request;
     if ((this->getResourceType() == ResType::AUTO_INDEX) ||
          this->getStatusCode().front() != '2')
     {
-        (this->getResourceType() != ResType::AUTO_INDEX) ?
-            PageGenerator::makeErrorPage(*this) :
+        if (this->getResourceType() != ResType::AUTO_INDEX)
+        {
+            std::cout<<"Debug 1"<<std::endl;
+            PageGenerator::makeErrorPage(*this);
+        }
+        else
+        {
+            std::cout<<"Debug 2"<<std::endl;
             PageGenerator::makeAutoIndex(*this);
+        }
     }
     else // 일반적인 body
     {

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -312,24 +312,15 @@ Response::makeStatusLine()
 void
 Response::makeBody(Request& request)
 {
-    // std::string body;
     Log::trace("> makeBody");
-    std::cout<<request<<std::endl;
-    std::cout<<"=================="<<std::endl;
     (void)request;
     if ((this->getResourceType() == ResType::AUTO_INDEX) ||
          this->getStatusCode().front() != '2')
     {
         if (this->getResourceType() != ResType::AUTO_INDEX)
-        {
-            std::cout<<"Debug 1"<<std::endl;
             PageGenerator::makeErrorPage(*this);
-        }
         else
-        {
-            std::cout<<"Debug 2"<<std::endl;
             PageGenerator::makeAutoIndex(*this);
-        }
     }
     else // 일반적인 body
     {

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -237,16 +237,19 @@ Response::initStatusCodeTable()
 void
 Response::applyAndCheckRequest(Request& request, Server* server)
 {
+    Log::trace("> applyAndCheckRequest");
     if (this->setRouteAndLocationInfo(request.getUri(), server))
     {
         if (this->isLimitExceptInLocation() && this->isAllowedMethod(request.getMethod()) == false)
             this->setStatusCode("405");
     }
+    Log::trace("< applyAndCheckRequest");
 }
 
 bool
 Response::setRouteAndLocationInfo(const std::string& uri, Server* server)
 {
+    Log::trace("> setRouteAndLocationInfo");
     std::map<std::string, location_info> location_config = server->getLocationConfig();
     std::string route;
 
@@ -277,12 +280,14 @@ Response::setRouteAndLocationInfo(const std::string& uri, Server* server)
             break ;
         }
     }
+    Log::trace("< setRouteAndLocationInfo");
     return (false);
 }
 
 std::string
 Response::makeStatusLine()
 {
+    Log::trace("> makeStatusLine");
     std::string status_line;
 
     this->setStatusCode(std::string("400"));
@@ -291,6 +296,7 @@ Response::makeStatusLine()
     status_line += " ";
     status_line += this->getStatusMessage(this->getStatusCode());
     status_line += "\r\n";
+    Log::trace("< makeStatusLine");
     return (status_line);
 }
 
@@ -307,7 +313,7 @@ void
 Response::makeBody(Request& request)
 {
     // std::string body;
-    Log::error("in makeBody\n");
+    Log::trace("> makeBody");
     std::cout<<request<<std::endl;
     std::cout<<"=================="<<std::endl;
     (void)request;
@@ -328,6 +334,7 @@ Response::makeBody(Request& request)
     else // 일반적인 body
     {
     }
+    Log::trace("< makeBody");
 }
 
 bool

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -216,19 +216,7 @@ Server::readBufferUntilHeaders(int fd, char* buf, size_t header_end_pos)
     Request& req = this->_requests[fd];
 
     if ((bytes = read(fd, buf, header_end_pos + 4)) > 0)
-    {
-        // int tmp;
-        // if ((tmp = read(fd, buf, 100)) > 0)
-        //     std::cout<<"Buffer left!!;;;"<<std::endl;
-        // else if (tmp == 0)
-        //     std::cout<<"eof"<<std::endl;
-        // else
-        //     std::cout<<"read error"<<std::endl;
-        // std::cout<<"bytes: "<< bytes<<std::endl;
-        
         req.parseRequestWithoutBody(buf);
-
-    }
     else if (bytes == 0)
         throw (Request::RequestFormatException(req, "400"));
     else


### PR DESCRIPTION
문제상황: 
  1. 오토인덱스를 리퀘스트로 주면 write 부분으로 들어오지 않음.
  2. 이 상태에서 클라이언트를 종료하면 서버에서는 종료된 클라이언트에게 리퀘스트를 무한으로 받는다.

원인:
  - ResInfo가 Autoindex로 셋팅된 경우, 더 읽어야할 관련 리소스가 없으므로 write_fdset이 되어야합니다. 그러나 이 부분 구현이 되어있지 않았습니다.

해결:
  - ResInfo가 Autoindex로 셋팅된 경우, 더 읽어야할 관련 리소스가 없으므로 write_fdset 시켰습니다.