### PR TITLE
Feat/close function

### DIFF
--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -22,6 +22,7 @@ public:
     static void serverIsCreated(Server& server);
     static void newClient(Server& server, int client_fd);
     static void closeClient(Server& server, int client_fd);
+    static void closeFd(Server& server, int client_socket, const FdType& type, int fd);
     static void getRequest(Server& server, int fd);
     static void timeLog(int fd);
     // error
@@ -31,6 +32,7 @@ public:
 
     // trace
     static void trace(const std::string& message);
+    static std::string fdTypeToString(const FdType& type);
 
 };
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -67,8 +67,8 @@ public:
     /* Exception */
 
     /* Util */
-    bool closeClientSocket(int fd);
-    bool closeFdAndSetClientOnWriteFdSet(int fd);
+    void closeClientSocket(int fd);
+    void closeFdAndSetClientOnWriteFdSet(int fd);
     bool isFdManagedByServer(int fd) const;
     bool isServerSocket(int fd) const;
     bool isClientSocket(int fd) const;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -68,6 +68,7 @@ public:
 
     /* Util */
     bool closeClientSocket(int fd);
+    bool closeFdAndSetClientOnWriteFdSet(int fd);
     bool isFdManagedByServer(int fd) const;
     bool isServerSocket(int fd) const;
     bool isClientSocket(int fd) const;

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -101,6 +101,50 @@ Log::closeClient(Server& server, int client_fd)
     write(fd, line.c_str(), line.length());
 }
 
+std::string
+Log::fdTypeToString(const FdType& type)
+{
+    switch (type)
+    {
+    case FdType::SERVER_SOCKET:
+        return ("SERVER");
+
+    case FdType::CLIENT_SOCKET:
+        return ("CLIENT");
+
+    case FdType::RESOURCE:
+        return ("RESOURCE");
+
+    case FdType::PIPE:
+        return ("PIPE");
+
+    case FdType::CLOSED:
+        return ("CLOSED");
+
+    default:
+        break;
+    }
+}
+
+void
+Log::closeFd(Server& server, int client_socket, const FdType& type, int fd)
+{
+    if (DEBUG == 0)
+        return ;
+
+    int server_fd = server.getServerSocket();
+    int log_print_fd = (STDOUT == 1) ? 1 : Log::access_fd;
+
+    std::string line;
+    line = "SERVER(" + std::to_string(server_fd) + ") CLOSE " 
+                    + fdTypeToString(type) + "(" + std::to_string(fd) 
+                    + ") which requested by CLIENT(" 
+                    + std::to_string(client_socket) + ")\n";
+
+    Log::timeLog(log_print_fd);
+    write(log_print_fd, line.c_str(), line.length());
+}
+
 void
 Log::getRequest(Server& server, int client_fd)
 {

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -113,7 +113,7 @@ Log::fdTypeToString(const FdType& type)
         return ("CLIENT");
 
     case FdType::RESOURCE:
-        return ("RESOURCE");
+        return ("STATIC_RESOURCE");
 
     case FdType::PIPE:
         return ("PIPE");

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -599,7 +599,9 @@ Server::closeClientSocket(int fd)
 bool
 Server::closeFdAndSetClientOnWriteFdSet(int fd)
 {
+    const FdType& type = this->_server_manager->getFdTable()[fd].first;
     int client_socket = this->_server_manager->getFdTable()[fd].second;
+    Log::closeFd(*this, client_socket, type, fd);
 
     this->_server_manager->fdClr(fd, FdSet::READ);
     this->_server_manager->setClosedFdOnFdTable(fd);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -637,27 +637,16 @@ Server::readStaticResource(int fd)
     {
         this->_responses[client_socket].appendBody(buf);
         if (bytes < BUFFER_SIZE)
-        {
-            closeFdAndSetClientOnWriteFdSet(fd);
-            // this->_server_manager->fdClr(fd, FdSet::READ);
-            // this->_server_manager->setClosedFdOnFdTable(fd);
-            // this->_server_manager->updateFdMax(fd);
-            // this->_server_manager->fdSet(client_socket, FdSet::WRITE);
-            // close(fd);
-        }
+            this->closeFdAndSetClientOnWriteFdSet(fd);
     }
     else if (bytes == 0)
     {
-        this->_server_manager->fdClr(fd, FdSet::READ);
-        this->_server_manager->setClosedFdOnFdTable(fd);
-        this->_server_manager->updateFdMax(fd);
-        this->_server_manager->fdSet(client_socket, FdSet::WRITE);
-        close(fd);
+        this->closeFdAndSetClientOnWriteFdSet(fd);
         throw (ReadErrorException());
     }
     else
     {
-        close(fd);
+        this->closeFdAndSetClientOnWriteFdSet(fd);
         throw (ReadErrorException());
     }
     // Log::trace("< readStaticResource");

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -586,8 +586,6 @@ Server::closeClientSocket(int fd)
     int ret;
     Log::closeClient(*this, fd);
 
-    std::cout << "In Close" << std::endl;
-
     this->_server_manager->fdClr(fd, FdSet::READ);
     this->_server_manager->setClosedFdOnFdTable(fd);
     this->_server_manager->updateFdMax(fd);
@@ -595,6 +593,19 @@ Server::closeClientSocket(int fd)
     Log::closeClient(*this, fd);
     if ((ret = close(fd)) < 0)
         return (false);
+    return (true);
+}
+
+bool
+Server::closeFdAndSetClientOnWriteFdSet(int fd)
+{
+    int client_socket = this->_server_manager->getFdTable()[fd].second;
+
+    this->_server_manager->fdClr(fd, FdSet::READ);
+    this->_server_manager->setClosedFdOnFdTable(fd);
+    this->_server_manager->updateFdMax(fd);
+    this->_server_manager->fdSet(client_socket, FdSet::WRITE);
+    close(fd);
     return (true);
 }
 


### PR DESCRIPTION
CGI 작업하실 때 아래 함수도 이용해주세요~

- `closeFdAndSetClientOnWriteFdSet`
  - Static resource나 Pipe 의 fd를 더 이상 사용하지 않을 때 진행되어야할 일련 작업과 Log print를 진행합니다.

- `Log::closeFd`
  - closeFdAndSetClientOnWriteFdSet 가 실행될 경우 아래 예시처럼 log를 표시합니다.
  - ![image](https://user-images.githubusercontent.com/54612343/97968001-639d8400-1e01-11eb-91ed-592a86803b6b.png)
