### PR TITLE
Feat/utils inet ntoa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ STDOUT = -D STDOUT=1
 
 # MAIN_FILES = setRouteAndLocationInfo_test
 # MAIN_FILES = PageGenerator_test PageGenerator Log utils ServerManager ServerGenerator Server Response Request UriParser
-MAIN_FILES = strdup_test utils
+MAIN_FILES = inet_ntoa_test utils
 # MAIN_FILES = PageGenerator_test PageGenerator
 
 SRCS_PATH = $(MAIN_FILES)

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -34,6 +34,7 @@ namespace ft
     std::string getCurrentDateTime();
     size_t strlen(const char* str);
     char* strdup(const std::string& s);
+    std::string inetNtoA(const in_addr_t& client_address);
 }
 
 #endif

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -225,4 +225,13 @@ strdup(const std::string& s)
 	return (ret);
 }
 
+std::string
+inetNtoA(const in_addr_t& client_address)
+{
+     return (std::to_string(client_address % 256) + "."
+            + std::to_string((client_address / 256) % 256) + "."
+            + std::to_string((client_address / 256 / 256) % 256) + "."
+            + std::to_string((client_address / 256 / 256 / 256)));
+}
+
 }

--- a/tests/inet_ntoa_test.cpp
+++ b/tests/inet_ntoa_test.cpp
@@ -1,0 +1,19 @@
+#include "utils.hpp"
+#include <iostream>
+
+//NOTE: hToNL 함수를 거치고 나면 inetNtoA 함수에서 ipv4 주소가 거꾸로 출력됩니다. 사용 시 유의하시기 바랍니다.
+
+int main()
+{
+    unsigned long ip_addr_test1 = ft::hToNL(0x1020304); // 1.2.3.4
+    unsigned long ip_addr_test2 = 0xb90eac0; // 192.234.144.11
+    unsigned long ip_addr_test3 = 0x6601a8c0; // 192.168.1.192
+    unsigned long ip_addr_test4 = 0x100007f; // 127.0.0.1
+
+    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test1) << std::endl;
+    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test2) << std::endl;
+    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test3) << std::endl;
+    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test4) << std::endl;
+
+    return (0);
+}


### PR DESCRIPTION
CGI 프로그램의 환경변수로 저장될 REMOTE_ADDR 은 클라이언트의 ip주소를 필요로 하며, 그 형식은 ipv4가 되어야 합니다.

client socket을 accept 할 때 sock_addr client_addr 구조체 안에다가 sin_addr.s_addr 값을 세팅하게 되는데,

이 때 이 값을 std::string 타입의 ipv4 주소를 저장하도록 하는 함수를 만들었습니다.

```C
    unsigned long ip_addr_test1 = ft::hToNL(0x1020304); // 1.2.3.4
    unsigned long ip_addr_test2 = 0xb90eac0; // 192.234.144.11
    unsigned long ip_addr_test3 = 0x6601a8c0; // 192.168.1.192
    unsigned long ip_addr_test4 = 0x100007f; // 127.0.0.1

    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test1) << std::endl;
    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test2) << std::endl;
    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test3) << std::endl;
    std::cout << "IP Address: " << ft::inetNtoA(ip_addr_test4) << std::endl;
```

-> 출력결과

IP Address: 1.2.3.4
IP Address: 192.234.144.11
IP Address: 192.168.1.102
IP Address: 127.0.0.1