### PR TITLE
Fix/infinite loop with invalid request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ DEBUG = -D DEBUG=2
 STDOUT = -D STDOUT=1
 
 # MAIN_FILES = setRouteAndLocationInfo_test
-# MAIN_FILES = PageGenerator_test PageGenerator Log utils ServerManager ServerGenerator Server Response Request UriParser
-MAIN_FILES = strdup_test utils
+MAIN_FILES = makeResponseMessage_test PageGenerator Log utils ServerManager ServerGenerator Server Response Request UriParser
+# MAIN_FILES = strdup_test utils
 # MAIN_FILES = PageGenerator_test PageGenerator
 
 SRCS_PATH = $(MAIN_FILES)

--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -32,7 +32,10 @@ public:
 
     // trace
     static void trace(const std::string& message);
+
     static std::string fdTypeToString(const FdType& type);
+    static void printLocationConfig(const std::map<std::string, location_info>& loc_config);
+    static void printLocationInfo(const location_info& loc_info);
 
 };
 

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -96,7 +96,7 @@ public:
     public:
         RequestFormatException(Request& req, const std::string& status_code);
         RequestFormatException(Request& req);
-        virtual std::string s_what() const throw();
+        virtual const char* what() const throw();
     };
 };
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -85,7 +85,7 @@ public:
     void receiveRequestChunkedBody(int fd);
     void clearRequestBuffer(int fd);
     std::string makeResponseMessage(int fd);
-    bool sendResponse(std::string& response_meesage, int fd);
+    bool sendResponse(const std::string& response_meesage, int fd);
     bool isClientOfServer(int fd) const;
     bool isFileUri(const Request& request) const;
     bool isIndexFileExist(int fd);

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -202,6 +202,9 @@ Log::fdTypeToString(const FdType& type)
 void
 Log::printLocationConfig(const std::map<std::string, location_info>& loc_config)
 {
+    if (DEBUG != 2)
+        return ;
+
     for(auto& kv: loc_config)
     {
         std::cout<<"|==============================================="<<std::endl;
@@ -214,6 +217,9 @@ Log::printLocationConfig(const std::map<std::string, location_info>& loc_config)
 void
 Log::printLocationInfo(const location_info& loc_info)
 {
+    if (DEBUG != 2)
+        return ;
+
     for(auto& kv : loc_info)
         std::cout<<"| "<<kv.first<<" : "<<kv.second<<std::endl;
 }

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -101,31 +101,6 @@ Log::closeClient(Server& server, int client_fd)
     write(fd, line.c_str(), line.length());
 }
 
-std::string
-Log::fdTypeToString(const FdType& type)
-{
-    switch (type)
-    {
-    case FdType::SERVER_SOCKET:
-        return ("SERVER");
-
-    case FdType::CLIENT_SOCKET:
-        return ("CLIENT");
-
-    case FdType::RESOURCE:
-        return ("STATIC_RESOURCE");
-
-    case FdType::PIPE:
-        return ("PIPE");
-
-    case FdType::CLOSED:
-        return ("CLOSED");
-
-    default:
-        break;
-    }
-}
-
 void
 Log::closeFd(Server& server, int client_socket, const FdType& type, int fd)
 {
@@ -197,4 +172,48 @@ Log::trace(const std::string& trace)
     Log::timeLog(fd);
     write(fd, trace.c_str(), trace.length());
     write(fd, "\n", 1);
+}
+
+std::string
+Log::fdTypeToString(const FdType& type)
+{
+    switch (type)
+    {
+    case FdType::SERVER_SOCKET:
+        return ("SERVER");
+
+    case FdType::CLIENT_SOCKET:
+        return ("CLIENT");
+
+    case FdType::RESOURCE:
+        return ("STATIC_RESOURCE");
+
+    case FdType::PIPE:
+        return ("PIPE");
+
+    case FdType::CLOSED:
+        return ("CLOSED");
+
+    default:
+        break;
+    }
+}
+
+void
+Log::printLocationConfig(const std::map<std::string, location_info>& loc_config)
+{
+    for(auto& kv: loc_config)
+    {
+        std::cout<<"|==============================================="<<std::endl;
+        std::cout<<"| Route: "<<kv.first<<std::endl;
+        printLocationInfo(kv.second);
+    }
+        std::cout<<"|==============================================="<<std::endl;
+}
+
+void
+Log::printLocationInfo(const location_info& loc_info)
+{
+    for(auto& kv : loc_info)
+        std::cout<<"| "<<kv.first<<" : "<<kv.second<<std::endl;
 }

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -162,21 +162,18 @@ Request::setIsBufferLeft(const bool& is_left_buffer)
 /*============================================================================*/
 
 Request::RequestFormatException::RequestFormatException(Request& req, const std::string& status_code)
-: _msg("RequestFormatException: Invalid Request Format: "), _req(req) 
+: _msg("RequestFormatException: Invalid Request Format: " + status_code), _req(req) 
 {
-    req.setStatusCode(status_code);
+    this->_req.setStatusCode(status_code);
 }
 
 Request::RequestFormatException::RequestFormatException(Request& req)
 : _msg("RequestFormatException: Invalid Request Format: "), _req(req) {}
 
-std::string
-Request::RequestFormatException::s_what() const throw()
+const char*
+Request::RequestFormatException::what() const throw()
 {
-    std::string tmp;
-    tmp += this->_msg;
-    tmp += this->_req.getStatusCode();
-    return (tmp);
+    return (this->_msg.c_str());
 }
 
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -247,12 +247,15 @@ Response::applyAndCheckRequest(Request& request, Server* server)
     Log::trace("< applyAndCheckRequest");
 }
 
+//NOTE
 bool
 Response::setRouteAndLocationInfo(const std::string& uri, Server* server)
 {
     Log::trace("> setRouteAndLocationInfo");
     std::map<std::string, location_info> location_config = server->getLocationConfig();
     std::string route;
+
+    Log::printLocationConfig(location_config);
 
     if (uri.length() == 1)
     {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -588,13 +588,9 @@ Server::run(int fd)
             {
                 std::cerr << e.what() << '\n';
                 if (this->_requests[fd].isContentLeftInBuffer())
-                {
-                    std::cout<<"Debug 1"<<std::endl;
                     this->_requests[fd].setReqInfo(ReqInfo::MUST_CLEAR);
-                }
                 else
                 {
-                    std::cout<<"Debug 2"<<std::endl;
                     this->_requests[fd].setReqInfo(ReqInfo::COMPLETE);
                     this->_server_manager->fdSet(fd, FdSet::WRITE);
                 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -522,15 +522,11 @@ void
 Server::acceptClient()
 {
     int client_socket;
-    int client_len;
-    struct sockaddr_in client_address;
+    struct sockaddr client_address;
+    socklen_t client_len = sizeof(client_address);
 
-    if ((client_socket = accept(this->getServerSocket(),
-        reinterpret_cast<struct sockaddr *>(&client_address),
-        reinterpret_cast<socklen_t *>(&client_len))) != -1)
+    if ((client_socket = accept(this->getServerSocket(), &client_address, &client_len)))
     {
-        if (client_socket > this->_server_manager->getFdMax())
-            this->_server_manager->setFdMax(client_socket);
         this->_server_manager->fdSet(client_socket, FdSet::READ);
         fcntl(client_socket, F_SETFL, O_NONBLOCK);
         this->_server_manager->setClientSocketOnFdTable(client_socket, this->getServerSocket());

--- a/tests/folder/index.html
+++ b/tests/folder/index.html
@@ -1,11 +1,10 @@
-asdf
-asd
-fas
-df
-asdf
-asdf
-asd
-f
-asdf
-sad
-f
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>index.html</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h1><a href="index.html">HTML</a></h1>
+  </body>
+</html>

--- a/tests/iwoo_config
+++ b/tests/iwoo_config
@@ -1,0 +1,27 @@
+http { 
+    include mime.types;
+    root /Users/humblego/Documents/dev/team_webserv/;
+    server {
+        server_name first_server;
+        listen       8080;
+
+        location /folder {
+            cgi .bin .cgi .bla;
+            autoindex on;
+            root /Users/humblego/Documents/dev/team_webserv/tests/;
+        }
+    }
+    server {
+        server_name second_server;
+        listen       8081;
+        location /first {
+            index  index.html index.htm;
+        }
+        location /second {
+            root  /user/iwoo;
+            index  html;
+            limit_except PUT POST GET
+            index index.html index.htm index.abc;
+        }
+    }
+}

--- a/tests/iwoo_config
+++ b/tests/iwoo_config
@@ -1,6 +1,6 @@
 http { 
     include mime.types;
-    root /Users/humblego/Documents/dev/team_webserv/;
+    root /Users/iwoo/Documents/Webserv/;
     server {
         server_name first_server;
         listen       8080;
@@ -8,7 +8,7 @@ http {
         location /folder {
             cgi .bin .cgi .bla;
             autoindex on;
-            root /Users/humblego/Documents/dev/team_webserv/tests/;
+            root /Users/iwoo/Documents/Webserv/tests/;
         }
     }
     server {
@@ -18,7 +18,7 @@ http {
             index  index.html index.htm;
         }
         location /second {
-            root  /user/iwoo;
+            root /Users/humblego/Documents/dev/team_webserv/tests/;
             index  html;
             limit_except PUT POST GET
             index index.html index.htm index.abc;

--- a/tests/makeResponseMessage_test.cpp
+++ b/tests/makeResponseMessage_test.cpp
@@ -16,6 +16,7 @@ int main(int argc, char *argv[], char *envp[])
     }
 
     const char *default_path = "tests/iwoo_config";
+    // const char *default_path = "tests/config_testfile";
     const char *config_path = (argc == 1) ? default_path : argv[1];
     try
     {

--- a/tests/makeResponseMessage_test.cpp
+++ b/tests/makeResponseMessage_test.cpp
@@ -1,0 +1,43 @@
+#include "PageGenerator.hpp"
+#include "Log.hpp"
+#include <iostream>
+#include "ServerManager.hpp"
+#include "Server.hpp"
+#include "Request.hpp"
+#include "Response.hpp"
+
+int main(int argc, char *argv[], char *envp[])
+{
+    (void)envp;
+    if (argc > 2)
+    {
+        //TODO: error message
+        return (EXIT_FAILURE);
+    }
+
+    const char *default_path = "tests/iwoo_config";
+    const char *config_path = (argc == 1) ? default_path : argv[1];
+    try
+    {
+        ServerManager server_manager(config_path);
+        if (!server_manager.runServers())
+        {
+            std::cerr<<"error"<<std::endl;
+        }
+        else
+        {
+            std::cout<<"success run server"<<std::endl;
+        }
+        
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << e.what() << '\n';
+    }
+    catch(const char *e)
+    {
+        std::cerr<<e<<std::endl;
+    }
+ 
+    return (0);
+}


### PR DESCRIPTION
### 문제
  - Telnet 테스트시에, `GET /folder/file_open_test HTTP/1.1` 문자열을 서버에 send하면, 서버가 무한 loop에 빠져서 receive를 반복했습니다.

### 원인
  - 무한루프를 도는 이유는 client_socket의 read buffer가 비워지지 않아서 select를 거칠 때마다 READ_SET이 셋팅되었기 때문입니다.
  - 이를 방지하기 위해 에러 메세지를 보내기 전에 read buffer를 비워줄 필요가 있는 것인데요, 이는 Request가 `ReqInfo::MUST_CLEAR`로 셋팅되면 처리됩니다. 
  - 그리고 이는 Invalid한 Request가 도착했을 때, parsing 과정에서 RequestFormatException을 던져질 경우 catch 구문에서 _is_left_buffer 변수를 조사하여 `ReqInfo::MUST_CLEAR`인지 여부를 확인하도록 구현해뒀었습니다.
  - **하지만 RequestFormatException을 던지기 전에 _is_left_buffer를 true 값으로 바꿔주지 않았기 때문에 catch 구문에서 `ReqInfo::Must_CLEAR`로 변경시키는 코드가 의도대로 동작하지 않은 것을 확인하였습니다.**

### 해결
  - RequestFormatException을 던지기 전에 _is_left_buffer를 true로 바꾸어 해결하였습니다.