### PR TITLE
Refactor/server authfile

### DIFF
--- a/.htpasswd
+++ b/.htpasswd
@@ -1,0 +1,1 @@
+c2FuYW06MTIzMTIz

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -65,6 +65,8 @@ public:
     const std::string& getPort() const;
     /* Setter */
     void setServerSocket();
+    void setAuthBasic(const std::string& auth_basic, const std::string& route);
+    void setAuthBasicUserFile(const std::string& decoded_id_password, const std::string& route);
 
     /* Exception */
 
@@ -105,6 +107,8 @@ public:
     void readStaticResource(int fd);
 
     void checkAuthenticate(int fd);
+
+    void setAuthenticateRealm();
 
     /* Server run function */
     void acceptClient();

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -300,13 +300,13 @@ Server::init()
 }
 
 void
-Server::readBufferUntilHeaders(int fd, char* buf, size_t header_end_pos)
+Server::readBufferUntilHeaders(int client_fd, char* buf, size_t header_end_pos)
 {
     Log::trace("> readBufferUntilHeaders");
     int bytes;
-    Request& req = this->_requests[fd];
+    Request& req = this->_requests[client_fd];
 
-    if ((bytes = read(fd, buf, header_end_pos + 4)) > 0)
+    if ((bytes = read(client_fd, buf, header_end_pos + 4)) > 0)
         req.parseRequestWithoutBody(buf);
     else if (bytes == 0)
         throw (Request::RequestFormatException(req, "400"));
@@ -316,16 +316,16 @@ Server::readBufferUntilHeaders(int fd, char* buf, size_t header_end_pos)
 }
 
 void
-Server::receiveRequestWithoutBody(int fd)
+Server::receiveRequestWithoutBody(int client_fd)
 {
     Log::trace("> receiveRequestWithoutBody");
     int bytes;
     char buf[BUFFER_SIZE + 1];
     size_t header_end_pos = 0;
-    Request& req = this->_requests[fd];
+    Request& req = this->_requests[client_fd];
 
     ft::memset(reinterpret_cast<void *>(buf), 0, BUFFER_SIZE + 1);
-    if ((bytes = recv(fd, buf, BUFFER_SIZE, MSG_PEEK)) > 0)
+    if ((bytes = recv(client_fd, buf, BUFFER_SIZE, MSG_PEEK)) > 0)
     {
         if ((header_end_pos = std::string(buf).find("\r\n\r\n")) != std::string::npos)
         {
@@ -336,7 +336,7 @@ Server::receiveRequestWithoutBody(int fd)
             }
             else
                 req.setIsBufferLeft(true);
-            this->readBufferUntilHeaders(fd, buf, header_end_pos);
+            this->readBufferUntilHeaders(client_fd, buf, header_end_pos);
         }
         else
         {
@@ -346,19 +346,19 @@ Server::receiveRequestWithoutBody(int fd)
         }
     }
     else if (bytes == 0)
-        this->closeClientSocket(fd);
+        this->closeClientSocket(client_fd);
     else
         throw (ReadErrorException());
     Log::trace("< receiveRequestWithoutBody");
 }
 
 void
-Server::receiveRequestNormalBody(int fd)
+Server::receiveRequestNormalBody(int client_fd)
 {
     Log::trace("> receiveRequestNormalBody");
 
     int bytes;
-    Request& req = this->_requests[fd];
+    Request& req = this->_requests[client_fd];
 
     int content_length = req.getContentLength();
     if (content_length > this->_limit_client_body_size)
@@ -367,10 +367,10 @@ Server::receiveRequestNormalBody(int fd)
     char buf[BUFFER_SIZE + 1];
     ft::memset(reinterpret_cast<void *>(buf), 0, BUFFER_SIZE + 1);
 
-    if ((bytes = recv(fd, buf, content_length, 0)) > 0)
+    if ((bytes = recv(client_fd, buf, content_length, 0)) > 0)
         req.parseNormalBodies(buf);
     else if (bytes == 0)
-        this->closeClientSocket(fd);
+        this->closeClientSocket(client_fd);
     else
         throw (ReadErrorException());
 
@@ -378,66 +378,66 @@ Server::receiveRequestNormalBody(int fd)
 }
 
 void
-Server::clearRequestBuffer(int fd)
+Server::clearRequestBuffer(int client_fd)
 {
     Log::trace("> clearRequestBuffer");
     int bytes;
     char buf[BUFFER_SIZE + 1];
-    Request& req = this->_requests[fd];
+    Request& req = this->_requests[client_fd];
 
-    if ((bytes = recv(fd, buf, BUFFER_SIZE, 0)) > 0)
+    if ((bytes = recv(client_fd, buf, BUFFER_SIZE, 0)) > 0)
     {
         if (bytes == BUFFER_SIZE)
             return ;
         req.setReqInfo(ReqInfo::COMPLETE);
     }
     else if (bytes == 0)
-        this->closeClientSocket(fd);
+        this->closeClientSocket(client_fd);
     else
         throw (ReadErrorException());
     Log::trace("< clearRequestBuffer");
 }
 
 void
-Server::receiveRequestChunkedBody(int fd)
+Server::receiveRequestChunkedBody(int client_fd)
 {
     Log::trace("> receiveRequestChunkedBody");
     int bytes;
     char buf[BUFFER_SIZE + 1];
-    Request& req = this->_requests[fd];
+    Request& req = this->_requests[client_fd];
 
-    if ((bytes = recv(fd, buf, BUFFER_SIZE, 0)) > 0)
+    if ((bytes = recv(client_fd, buf, BUFFER_SIZE, 0)) > 0)
         req.parseChunkedBody(buf);
     else if (bytes == 0)
-        this->closeClientSocket(fd);
+        this->closeClientSocket(client_fd);
     else
         throw (ReadErrorException());
     Log::trace("< receiveRequestChunkedBody");
 }
 
 void
-Server::receiveRequest(int fd)
+Server::receiveRequest(int client_fd)
 {
     Log::trace("> receiveRequest");
 
-    const ReqInfo& req_info = this->_requests[fd].getReqInfo();
+    const ReqInfo& req_info = this->_requests[client_fd].getReqInfo();
 
     switch (req_info)
     {
     case ReqInfo::READY:
-        this->receiveRequestWithoutBody(fd);
+        this->receiveRequestWithoutBody(client_fd);
         break ;
 
     case ReqInfo::NORMAL_BODY:
-        this->receiveRequestNormalBody(fd);
+        this->receiveRequestNormalBody(client_fd);
         break ;
 
     case ReqInfo::CHUNKED_BODY:
-        this->receiveRequestChunkedBody(fd);
+        this->receiveRequestChunkedBody(client_fd);
         break ;
 
     case ReqInfo::MUST_CLEAR:
-        this->clearRequestBuffer(fd);
+        this->clearRequestBuffer(client_fd);
         break ;
 
     default:
@@ -448,11 +448,11 @@ Server::receiveRequest(int fd)
 }
 
 std::string
-Server::makeResponseMessage(int fd)
+Server::makeResponseMessage(int client_fd)
 {
     Log::trace("> makeResponseMessage");
-    Request& request = this->_requests[fd];
-    Response& response = this->_responses[fd];
+    Request& request = this->_requests[client_fd];
+    Response& response = this->_responses[client_fd];
 
     std::string status_line;
     std::string headers;
@@ -472,14 +472,14 @@ Server::makeResponseMessage(int fd)
 }
 
 bool
-Server::sendResponse(const std::string& response_message, int fd)
+Server::sendResponse(const std::string& response_message, int client_fd)
 {
     Log::trace("> sendResponse");
     std::string tmp;
     tmp += response_message;
     tmp += "\r\n";
     std::cout<<tmp<<std::endl;
-    write(fd, tmp.c_str(), tmp.length()); 
+    write(client_fd, tmp.c_str(), tmp.length()); 
     Log::trace("< sendResponse");
     return (true);
 }
@@ -566,10 +566,10 @@ Server::isCGIPipe(int fd) const
 }
 
 bool
-Server::isIndexFileExist(int fd)
+Server::isIndexFileExist(int client_fd)
 {
-    const std::string& dir_entry = this->_responses[fd].getDirectoryEntry();
-    const location_info& location_info = this->_responses[fd].getLocationInfo();
+    const std::string& dir_entry = this->_responses[client_fd].getDirectoryEntry();
+    const location_info& location_info = this->_responses[client_fd].getLocationInfo();
     std::vector<std::string> indexs = ft::split(location_info.at("index"), " ");
     for (std::string& index : indexs)
     {
@@ -580,9 +580,9 @@ Server::isIndexFileExist(int fd)
 }
 
 bool
-Server::isAutoIndexOn(int fd)
+Server::isAutoIndexOn(int client_fd)
 {
-    const location_info& location_info = this->_responses[fd].getLocationInfo();
+    const location_info& location_info = this->_responses[client_fd].getLocationInfo();
     Log::printLocationInfo(location_info);
     if (location_info.at("autoindex") == "on")
         return (true);
@@ -590,7 +590,7 @@ Server::isAutoIndexOn(int fd)
 }
 
 bool
-Server::isCGIUri(int fd, const std::string& extension)
+Server::isCGIUri(int client_fd, const std::string& extension)
 {
     Log::trace("> isCGIUri");
 
@@ -600,7 +600,7 @@ Server::isCGIUri(int fd, const std::string& extension)
         return (false);
     }
 
-    const location_info& location_info = this->_responses[fd].getLocationInfo();
+    const location_info& location_info = this->_responses[client_fd].getLocationInfo();
     location_info::const_iterator it = location_info.find("cgi");
     if (it == location_info.end())
     {
@@ -801,14 +801,14 @@ Server::run(int fd)
 }
 
 void
-Server::closeClientSocket(int fd)
+Server::closeClientSocket(int client_fd)
 {
-    this->_server_manager->fdClr(fd, FdSet::READ);
-    this->_server_manager->setClosedFdOnFdTable(fd);
-    this->_server_manager->updateFdMax(fd);
-    this->_requests[fd].init();
-    Log::closeClient(*this, fd);
-    close(fd);
+    this->_server_manager->fdClr(client_fd, FdSet::READ);
+    this->_server_manager->setClosedFdOnFdTable(client_fd);
+    this->_server_manager->updateFdMax(client_fd);
+    this->_requests[client_fd].init();
+    Log::closeClient(*this, client_fd);
+    close(client_fd);
 }
 
 void
@@ -839,17 +839,14 @@ Server::closeFdAndSetFd(int clear_fd, FdSet clear_fd_set, int set_fd, FdSet set_
     close(clear_fd);
     Log::trace("< closeFdAndSetFd");
 }
-//NOTE: 설정 파일에서는 auth_basic_user_file file_paht; 로 있음
-//NOTE: Server Generator에서 메인 반복문을 시작하기 전에
-//NOTE: 설정파일의 auth_basic_user_file을 읽고 미리 decode 해놓자
-//NOTE: 해당 value를 userid:password로 미리 세팅해주자
+
 void
-Server::checkAuthenticate(int fd) //NOTE: fd: client_fd
+Server::checkAuthenticate(int client_fd)
 {
     std::string before_decode;
     std::string after_decode;
-    Response& response = this->_responses[fd];
-    Request& request = this->_requests[fd];
+    Response& response = this->_responses[client_fd];
+    Request& request = this->_requests[client_fd];
     const std::string& route = response.getRoute();
     const std::map<std::string, location_info>& location_config = this->getLocationConfig();
     const location_info& location_info = location_config.at(route);
@@ -860,17 +857,17 @@ Server::checkAuthenticate(int fd) //NOTE: fd: client_fd
     if (it == location_info.end())
         return ;
     const std::string& id_password = it->second;
-    const std::map<std::string, std::string>& headers = this->_requests[fd].getHeaders();
+    const std::map<std::string, std::string>& headers = this->_requests[client_fd].getHeaders();
     it = headers.find("Authorization");
     if (it == headers.end())
-        throw (AuthenticateErrorException(this->_responses[fd], "401"));
+        throw (AuthenticateErrorException(this->_responses[client_fd], "401"));
     std::vector<std::string> authenticate_info = ft::split(it->second, " ");
-    if (authenticate_info[0] != "Basic") //NOTE: 보안은 Basic 이용
-        throw (AuthenticateErrorException(this->_responses[fd], "401"));
+    if (authenticate_info[0] != "Basic")
+        throw (AuthenticateErrorException(this->_responses[client_fd], "401"));
     before_decode = authenticate_info[1];
     Base64::decode(before_decode, after_decode);
     if (id_password != after_decode)
-        throw (AuthenticateErrorException(this->_responses[fd], "403"));
+        throw (AuthenticateErrorException(this->_responses[client_fd], "403"));
     request.setAuthType(authenticate_info[0]);
     size_t pos = after_decode.find(":");
     request.setRemoteUser(after_decode.substr(0, pos));
@@ -879,14 +876,14 @@ Server::checkAuthenticate(int fd) //NOTE: fd: client_fd
 
 //TODO: 함수명이 기능을 담지 못함, 수정 필요함!
 void
-Server::findResourceAbsPath(int fd)
+Server::findResourceAbsPath(int client_fd)
 {
     Log::trace("> findResourceAbsPath");
     UriParser parser;
-    parser.parseUri(this->_requests[fd].getUri());
+    parser.parseUri(this->_requests[client_fd].getUri());
     const std::string& path = parser.getPath();
 
-    Response& response = this->_responses[fd];
+    Response& response = this->_responses[client_fd];
     response.setUriPath(path);
     response.setRouteAndLocationInfo(path, this);
 
@@ -899,65 +896,65 @@ Server::findResourceAbsPath(int fd)
 }
 
 void 
-Server::readStaticResource(int fd)
+Server::readStaticResource(int resource_fd)
 {
     Log::trace("> readStaticResource");
     char buf[BUFFER_SIZE + 1];
     int bytes;
-    int client_socket = this->_server_manager->getFdTable()[fd].second;
+    int client_socket = this->_server_manager->getFdTable()[resource_fd].second;
 
     ft::memset(buf, 0, BUFFER_SIZE + 1);
-    if ((bytes = read(fd, buf, BUFFER_SIZE)) > 0)
+    if ((bytes = read(resource_fd, buf, BUFFER_SIZE)) > 0)
     {
         this->_responses[client_socket].appendBody(buf);
         if (bytes < BUFFER_SIZE)
-            this->closeFdAndSetClientOnWriteFdSet(fd);
+            this->closeFdAndSetClientOnWriteFdSet(resource_fd);
     }
     else if (bytes == 0)
     {
-        this->closeFdAndSetClientOnWriteFdSet(fd);
+        this->closeFdAndSetClientOnWriteFdSet(resource_fd);
         throw (ReadErrorException());
     }
     else
     {
-        this->closeFdAndSetClientOnWriteFdSet(fd);
+        this->closeFdAndSetClientOnWriteFdSet(resource_fd);
         throw (ReadErrorException());
     }
     Log::trace("< readStaticResource");
 }
 
 void
-Server::openStaticResource(int fd)
+Server::openStaticResource(int client_fd)
 {
     Log::trace("> openStaticResource");
     int resource_fd;
-    const std::string& path = this->_responses[fd].getResourceAbsPath();
+    const std::string& path = this->_responses[client_fd].getResourceAbsPath();
     struct stat tmp;
 
     if ((resource_fd = open(path.c_str(), O_RDWR, 0644)) > 0)
     {
         fcntl(resource_fd, F_SETFL, O_NONBLOCK);
         this->_server_manager->fdSet(resource_fd, FdSet::READ);
-        this->_server_manager->setResourceOnFdTable(resource_fd, fd);
+        this->_server_manager->setResourceOnFdTable(resource_fd, client_fd);
         this->_server_manager->updateFdMax(resource_fd);
         if ((fstat(resource_fd, &tmp)) == -1)
-            throw OpenResourceErrorException(this->_responses[fd], errno);
-        this->_responses[fd].setFileInfo(tmp);
-        Log::openFd(*this, fd, FdType::RESOURCE, resource_fd);
+            throw OpenResourceErrorException(this->_responses[client_fd], errno);
+        this->_responses[client_fd].setFileInfo(tmp);
+        Log::openFd(*this, client_fd, FdType::RESOURCE, resource_fd);
     }
     else
-        throw OpenResourceErrorException(this->_responses[fd], errno);
+        throw OpenResourceErrorException(this->_responses[client_fd], errno);
     Log::trace("< openStaticResource");
 }
 
 void
-Server::checkAndSetResourceType(int fd)
+Server::checkAndSetResourceType(int client_fd)
 {
     Log::trace("> checkAndSetResourceType");
 
-    Response& response = this->_responses[fd];
+    Response& response = this->_responses[client_fd];
     response.findAndSetUriExtension();
-    if (this->isCGIUri(fd, response.getUriExtension()))
+    if (this->isCGIUri(client_fd, response.getUriExtension()))
     {
         response.setResourceType(ResType::CGI);
         return ;
@@ -967,14 +964,14 @@ Server::checkAndSetResourceType(int fd)
     {
         response.setDirectoryEntry(dir_ptr);
         closedir(dir_ptr);
-        if (this->isIndexFileExist(fd))
+        if (this->isIndexFileExist(client_fd))
             response.setResourceType(ResType::INDEX_HTML);
         else
         {
-            if (this->isAutoIndexOn(fd))
+            if (this->isAutoIndexOn(client_fd))
                 response.setResourceType(ResType::AUTO_INDEX);
             else
-                throw (IndexNoExistException(this->_responses[fd]));
+                throw (IndexNoExistException(this->_responses[client_fd]));
         }
     }
     else
@@ -982,55 +979,55 @@ Server::checkAndSetResourceType(int fd)
         if (errno == ENOTDIR)
             response.setResourceType(ResType::STATIC_RESOURCE);
         else if (errno == EACCES)
-            throw (CannotOpenDirectoryException(this->_responses[fd], "403", errno));
+            throw (CannotOpenDirectoryException(this->_responses[client_fd], "403", errno));
         else if (errno == ENOENT)
-            throw (CannotOpenDirectoryException(this->_responses[fd], "404", errno));
+            throw (CannotOpenDirectoryException(this->_responses[client_fd], "404", errno));
     }
 
     Log::trace("< checkAndSetResourceType");
 }
 
 void
-Server::preprocessResponseBody(int fd, ResType& res_type)
+Server::preprocessResponseBody(int client_fd, ResType& res_type)
 {
     Log::trace("> preprocessResponseBody");
     switch (res_type)
     {
     case ResType::AUTO_INDEX:
         std::cout << "Auto index page will be generated" << std::endl;
-        this->_server_manager->fdSet(fd, FdSet::WRITE);
+        this->_server_manager->fdSet(client_fd, FdSet::WRITE);
         break ;
     case ResType::STATIC_RESOURCE:
         std::cout << "Static resource will be opened" << std::endl;
-        this->openStaticResource(fd);
+        this->openStaticResource(client_fd);
         break ;
     case ResType::CGI:
         std::cout << "CGIpipe will be opened" << std::endl;
-        this->openCGIPipe(fd);
-        this->forkAndExecuteCGI(fd);
+        this->openCGIPipe(client_fd);
+        this->forkAndExecuteCGI(client_fd);
         break ;
     default:
-        this->_server_manager->fdSet(fd, FdSet::WRITE);
+        this->_server_manager->fdSet(client_fd, FdSet::WRITE);
         break ;
     }
     Log::trace("< preprocessResponseBody");
 }
 
 void
-Server::processResponseBody(int fd)
+Server::processResponseBody(int client_fd)
 {
     Log::trace("> processResopnseBody");
 
-    std::cout<<"uri: "<<this->_requests[fd].getUri()<<std::endl;
-    this->findResourceAbsPath(fd);
-    this->checkAuthenticate(fd);
-    if (this->_responses[fd].isLocationToBeRedirected())
-        throw (MustRedirectException(this->_responses[fd]));
-    this->checkAndSetResourceType(fd);
-    if (this->_responses[fd].getResourceType() == ResType::INDEX_HTML)
-        this->setResourceAbsPathAsIndex(fd);
-    ResType res_type = this->_responses[fd].getResourceType();
-    this->preprocessResponseBody(fd, res_type);
+    std::cout<<"uri: "<<this->_requests[client_fd].getUri()<<std::endl;
+    this->findResourceAbsPath(client_fd);
+    this->checkAuthenticate(client_fd);
+    if (this->_responses[client_fd].isLocationToBeRedirected())
+        throw (MustRedirectException(this->_responses[client_fd]));
+    this->checkAndSetResourceType(client_fd);
+    if (this->_responses[client_fd].getResourceType() == ResType::INDEX_HTML)
+        this->setResourceAbsPathAsIndex(client_fd);
+    ResType res_type = this->_responses[client_fd].getResourceType();
+    this->preprocessResponseBody(client_fd, res_type);
     Log::trace("< processResopnseBody");
 }
 

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -236,7 +236,7 @@ ServerGenerator::initHttpConfig(server_info& http_config)
 void
 ServerGenerator::initServerConfig(server_info& server_config, server_info& http_config)
 {
-    std::map<std::string, std::string>::iterator ite = http_config.end();
+    const std::map<std::string, std::string>::iterator& ite = http_config.end();
 
     server_config["listen"] = std::to_string(8080);
     server_config["client_max_body_size"] = std::string("1m");
@@ -248,8 +248,8 @@ ServerGenerator::initServerConfig(server_info& server_config, server_info& http_
         server_config["autoindex"] = http_config["autoindex"];
     if (http_config.find("auth_basic") != ite)
         server_config["auth_basic"] = http_config["auth_basic"];
-    if (http_config.find("auth_basic_file") != ite)
-        server_config["auth_basic_file"] = http_config["auth_basic_file"];
+    if (http_config.find("auth_basic_user_file") != ite)
+        server_config["auth_basic_user_file"] = http_config["auth_basic_file"];
     if (http_config.find("error_page") != ite)
         server_config["error_page"] = http_config["error_page"];
     if (http_config.find("retry_after_sec") != ite)
@@ -259,7 +259,7 @@ ServerGenerator::initServerConfig(server_info& server_config, server_info& http_
 void
 ServerGenerator::initLocationConfig(location_info& location_config, server_info& server_config)
 {
-    std::map<std::string, std::string>::iterator ite = server_config.end();
+    const std::map<std::string, std::string>::iterator& ite = server_config.end();
 
     if (server_config.find("root") != ite)
         location_config["root"] = server_config["root"];
@@ -269,8 +269,8 @@ ServerGenerator::initLocationConfig(location_info& location_config, server_info&
         location_config["autoindex"] = server_config["autoindex"];
     if (server_config.find("auth_basic") != ite)
         location_config["auth_basic"] = server_config["auth_basic"];
-    if (server_config.find("auth_basic_file") != ite)
-        location_config["auth_baasic_file"] = server_config["auth_basic_file"];
+    if (server_config.find("auth_basic_user_file") != ite)
+        location_config["auth_basic_user_file"] = server_config["auth_basic_file"];
     if (server_config.find("error_page") != ite)
         location_config["error_page"] = server_config["error_page"];
     if (server_config.find("retry_after_sec") != ite)

--- a/tests/sanam_testfile
+++ b/tests/sanam_testfile
@@ -10,7 +10,7 @@ http {
             autoindex on;
             root /Users/sanam/Desktop/Webserv/;
             auth_basic sanam;
-            auth_basic_user_file sanam:123123;
+            auth_basic_user_file /Users/sanam/Desktop/Webserv/.htpasswd;
         }
 
         location /directory {
@@ -18,5 +18,7 @@ http {
             index youpi.bad_extension;
             cgi .bla;
             cgi_path /Users/sanam/Desktop/Webserv/cgi_tester;
+            auth_basic sanam;
+            auth_basic_user_file /Users/sanam/Desktop/Webserv/.htpasswd;
     }
 }


### PR DESCRIPTION
서버의 init에서 location_config 를 확인한 다음에 auth_basic관련 처리를 합니다.

만약 `auth_basic` `off`가 아니고 `auth_basic_user_file`이 없거나 옳지 않은 파일이면 `auth_basic`은 `off`로 세팅이 됩니다. 그리고 해당 `location`은 보안 영역이 되지 않습니다.

`auth_basic`이 `off`가 아니고 `auth_basic_user_file` 이 옳은 파일이면 파일을 읽고, base64로 디코딩 한 다음에 `auth_basic_user_file`을 키로하는 설정의 value로 디코딩 된 값이 들어갑니다. 