### PR TITLE
Refactor/chunked

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -154,6 +154,19 @@ public:
     void appendRetryAfterHeader(std::string& headers, const std::string& status_code);
     void appendTransferEncodingHeader(std::string& headers);
     void appendAuthenticateHeader(std::string& headers);
+
+
+private:
+    OnRead _on_read;
+public:
+    const OnRead& getOnRead() const
+    {
+        return this->_on_read;
+    }
+    void setOnRead(const OnRead& on_read)
+    {
+        this->_on_read = on_read;
+    }
 };
 
 #endif

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -43,7 +43,7 @@ private:
     SendProgress _send_progress;
     ReceiveProgress _receive_progress;
 
-    int _linked_resoure_fd;
+    int _resoure_fd;
 
 public:
     /* Constructor */
@@ -84,7 +84,7 @@ public:
     const SendProgress& getSendProgress() const;
     const ReceiveProgress& getReceiveProgress() const;
 
-    int getLinkedResourceFd() const
+    int getResourceFd() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
@@ -107,7 +107,7 @@ public:
     void setAlreadyEncodedSize(const size_t already_encoded_size);
     void setSendProgress(const SendProgress send_progress);
     void setReceiveProgress(const ReceiveProgress rececive_progress);
-    void setLinkedResourceFd(const int resource_fd);
+    void setResourceFd(const int resource_fd);
 
     /* Exception */
 public:

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -43,6 +43,8 @@ private:
     SendProgress _send_progress;
     ReceiveProgress _receive_progress;
 
+    int _linked_resoure_fd;
+
 public:
     /* Constructor */
     Response();
@@ -82,6 +84,8 @@ public:
     const SendProgress& getSendProgress() const;
     const ReceiveProgress& getReceiveProgress() const;
 
+    int getLinkedResourceFd() const
+
     /* Setter */
     void setStatusCode(const std::string& status_code);
     void setResourceAbsPath(const std::string& path);
@@ -103,6 +107,7 @@ public:
     void setAlreadyEncodedSize(const size_t already_encoded_size);
     void setSendProgress(const SendProgress send_progress);
     void setReceiveProgress(const ReceiveProgress rececive_progress);
+    void setLinkedResourceFd(const int resource_fd);
 
     /* Exception */
 public:

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -41,6 +41,7 @@ private:
     size_t _already_encoded_size;
 
     SendProgress _send_progress;
+    ReceiveProgress _receive_progress;
 
 public:
     /* Constructor */
@@ -79,6 +80,7 @@ public:
 
     size_t getAlreadyEncodedSize() const;
     const SendProgress& getSendProgress() const;
+    const ReceiveProgress& getReceiveProgress() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
@@ -100,6 +102,7 @@ public:
 
     void setAlreadyEncodedSize(const size_t already_encoded_size);
     void setSendProgress(const SendProgress send_progress);
+    void setReceiveProgress(const ReceiveProgress rececive_progress);
 
     /* Exception */
 public:
@@ -155,18 +158,6 @@ public:
     void appendTransferEncodingHeader(std::string& headers);
     void appendAuthenticateHeader(std::string& headers);
 
-
-private:
-    OnRead _on_read;
-public:
-    const OnRead& getOnRead() const
-    {
-        return this->_on_read;
-    }
-    void setOnRead(const OnRead& on_read)
-    {
-        this->_on_read = on_read;
-    }
 };
 
 #endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -18,7 +18,7 @@
 # include "Response.hpp"
 # include "Exception.hpp"
 
-const int BUFFER_SIZE = 65534;
+const int BUFFER_SIZE = 500;
 const int CHUNKED_LINE_LENGTH = 8192;
 
 class ServerManager;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -73,7 +73,6 @@ public:
 
     /* Util */
     void closeClientSocket(int fd);
-    void closeFdAndSetClientOnWriteFdSet(int fd);
     void closeFdAndSetFd(int clear_fd, FdSet clear_fd_set, int set_fd, FdSet set_fd_set);
     bool isFdManagedByServer(int fd) const;
     bool isServerSocket(int fd) const;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -18,7 +18,7 @@
 # include "Response.hpp"
 # include "Exception.hpp"
 
-const int BUFFER_SIZE = 500;
+const int BUFFER_SIZE = 65532;
 const int CHUNKED_LINE_LENGTH = 8192;
 
 class ServerManager;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -18,7 +18,7 @@
 # include "Response.hpp"
 # include "Exception.hpp"
 
-const int BUFFER_SIZE = 65532;
+const int BUFFER_SIZE = 65536;
 const int CHUNKED_LINE_LENGTH = 8192;
 
 class ServerManager;

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -85,10 +85,10 @@ enum class SendProgress
     FINISH,
 };
 
-enum class OnRead
+enum class ReceiveProgress
 {
-    READING,
-    COMPLETE,
+    ON_GOING,
+    FINISH,
 };
 
 #endif

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -85,4 +85,10 @@ enum class SendProgress
     FINISH,
 };
 
+enum class OnRead
+{
+    READING,
+    COMPLETE,
+};
+
 #endif

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -21,7 +21,8 @@ _location_info({{"",""}}), _resource_abs_path(""), _route(""),
 _directory_entry(""), _resource_type(ResType::NOT_YET_CHECKED), _body(""),
 _stdin_of_cgi(0), _stdout_of_cgi(0), _read_fd_from_cgi(0), _write_fd_to_cgi(0), 
 _cgi_pid(0), _uri_path(""), _uri_extension(""), _transmitting_body(""),
-_already_encoded_size(0), _send_progress(SendProgress::DEFAULT)
+_already_encoded_size(0), _send_progress(SendProgress::DEFAULT),
+_receive_progress(ReceiveProgress::FINISH)
 {
     ft::memset(&this->_file_info, 0, sizeof(this->_file_info));
     this->initStatusCodeTable();
@@ -39,7 +40,8 @@ _body(other._body), _stdin_of_cgi(other._stdout_of_cgi),
 _stdout_of_cgi(other._stdout_of_cgi), _read_fd_from_cgi(other._read_fd_from_cgi),
 _write_fd_to_cgi(other._write_fd_to_cgi), _cgi_pid(other._cgi_pid),
 _uri_path(other._uri_path), _uri_extension(other._uri_extension), _transmitting_body(other._transmitting_body),
-_already_encoded_size(other._already_encoded_size), _send_progress(other._send_progress)
+_already_encoded_size(other._already_encoded_size), _send_progress(other._send_progress),
+_receive_progress(other._receive_progress)
 {}
 
 /*============================================================================*/
@@ -80,6 +82,7 @@ Response::operator=(const Response& rhs)
     this->_transmitting_body = rhs._transmitting_body;
     this->_already_encoded_size = rhs._already_encoded_size;
     this->_send_progress = rhs._send_progress;
+    this->_receive_progress = rhs._receive_progress;
     return (*this);
 }
 
@@ -207,6 +210,12 @@ Response::getSendProgress() const
     return (this->_send_progress);
 }
 
+const ReceiveProgress&
+Response::getReceiveProgress() const
+{
+    return (this->_receive_progress);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -312,6 +321,12 @@ void
 Response::setSendProgress(const SendProgress send_progress)
 {
     this->_send_progress = send_progress;
+}
+
+void
+Response::setReceiveProgress(const ReceiveProgress receive_progress)
+{
+    this->_receive_progress = receive_progress;
 }
 
 /*============================================================================*/
@@ -909,8 +924,8 @@ Response::encodeChunkedBody()
         this->setSendProgress(SendProgress::CHUNK_START);
     else if (this->getSendProgress() == SendProgress::CHUNK_START)
         this->setSendProgress(SendProgress::CHUNK_PROGRESS);
-        //NOTE 여기 바꿨어용
-    if (already_encoded_size == raw_body_size && getOnRead() == OnRead::COMPLETE)
+    if (already_encoded_size == raw_body_size &&
+            this->getReceiveProgress() == ReceiveProgress::FINISH)
     {
         chunked_body += "0\r\n\r\n";
         this->setSendProgress(SendProgress::FINISH);

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -22,7 +22,7 @@ _directory_entry(""), _resource_type(ResType::NOT_YET_CHECKED), _body(""),
 _stdin_of_cgi(0), _stdout_of_cgi(0), _read_fd_from_cgi(0), _write_fd_to_cgi(0), 
 _cgi_pid(0), _uri_path(""), _uri_extension(""), _transmitting_body(""),
 _already_encoded_size(0), _send_progress(SendProgress::DEFAULT),
-_receive_progress(ReceiveProgress::FINISH), _linked_resoure_fd(0)
+_receive_progress(ReceiveProgress::FINISH), _resoure_fd(0)
 {
     ft::memset(&this->_file_info, 0, sizeof(this->_file_info));
     this->initStatusCodeTable();
@@ -41,7 +41,7 @@ _stdout_of_cgi(other._stdout_of_cgi), _read_fd_from_cgi(other._read_fd_from_cgi)
 _write_fd_to_cgi(other._write_fd_to_cgi), _cgi_pid(other._cgi_pid),
 _uri_path(other._uri_path), _uri_extension(other._uri_extension), _transmitting_body(other._transmitting_body),
 _already_encoded_size(other._already_encoded_size), _send_progress(other._send_progress),
-_receive_progress(other._receive_progress), _linked_resoure_fd(other._linked_resoure_fd)
+_receive_progress(other._receive_progress), _resoure_fd(other._resoure_fd)
 {}
 
 /*============================================================================*/
@@ -83,7 +83,7 @@ Response::operator=(const Response& rhs)
     this->_already_encoded_size = rhs._already_encoded_size;
     this->_send_progress = rhs._send_progress;
     this->_receive_progress = rhs._receive_progress;
-    this->_linked_resoure_fd = rhs._linked_resoure_fd;
+    this->_resoure_fd = rhs._resoure_fd;
     return (*this);
 }
 
@@ -218,9 +218,9 @@ Response::getReceiveProgress() const
 }
 
 int
-Response::getLinkedResourceFd() const
+Response::getResourceFd() const
 {
-    return (this->_linked_resoure_fd);
+    return (this->_resoure_fd);
 }
 
 /*============================================================================*/
@@ -337,9 +337,9 @@ Response::setReceiveProgress(const ReceiveProgress receive_progress)
 }
 
 void
-Response::setLinkedResourceFd(const int resource_fd)
+Response::setResourceFd(const int resource_fd)
 {
-    this->_linked_resoure_fd = resource_fd;
+    this->_resoure_fd = resource_fd;
 }
 
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -22,7 +22,7 @@ _directory_entry(""), _resource_type(ResType::NOT_YET_CHECKED), _body(""),
 _stdin_of_cgi(0), _stdout_of_cgi(0), _read_fd_from_cgi(0), _write_fd_to_cgi(0), 
 _cgi_pid(0), _uri_path(""), _uri_extension(""), _transmitting_body(""),
 _already_encoded_size(0), _send_progress(SendProgress::DEFAULT),
-_receive_progress(ReceiveProgress::FINISH)
+_receive_progress(ReceiveProgress::FINISH), _linked_resoure_fd(0)
 {
     ft::memset(&this->_file_info, 0, sizeof(this->_file_info));
     this->initStatusCodeTable();
@@ -41,7 +41,7 @@ _stdout_of_cgi(other._stdout_of_cgi), _read_fd_from_cgi(other._read_fd_from_cgi)
 _write_fd_to_cgi(other._write_fd_to_cgi), _cgi_pid(other._cgi_pid),
 _uri_path(other._uri_path), _uri_extension(other._uri_extension), _transmitting_body(other._transmitting_body),
 _already_encoded_size(other._already_encoded_size), _send_progress(other._send_progress),
-_receive_progress(other._receive_progress)
+_receive_progress(other._receive_progress), _linked_resoure_fd(other._linked_resoure_fd)
 {}
 
 /*============================================================================*/
@@ -83,6 +83,7 @@ Response::operator=(const Response& rhs)
     this->_already_encoded_size = rhs._already_encoded_size;
     this->_send_progress = rhs._send_progress;
     this->_receive_progress = rhs._receive_progress;
+    this->_linked_resoure_fd = rhs._linked_resoure_fd;
     return (*this);
 }
 
@@ -216,6 +217,12 @@ Response::getReceiveProgress() const
     return (this->_receive_progress);
 }
 
+int
+Response::getLinkedResourceFd() const
+{
+    return (this->_linked_resoure_fd);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -327,6 +334,12 @@ void
 Response::setReceiveProgress(const ReceiveProgress receive_progress)
 {
     this->_receive_progress = receive_progress;
+}
+
+void
+Response::setLinkedResourceFd(const int resource_fd)
+{
+    this->_linked_resoure_fd = resource_fd;
 }
 
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -909,7 +909,8 @@ Response::encodeChunkedBody()
         this->setSendProgress(SendProgress::CHUNK_START);
     else if (this->getSendProgress() == SendProgress::CHUNK_START)
         this->setSendProgress(SendProgress::CHUNK_PROGRESS);
-    if (already_encoded_size == raw_body_size)
+        //NOTE 여기 바꿨어용
+    if (already_encoded_size == raw_body_size && getOnRead() == OnRead::COMPLETE)
     {
         chunked_body += "0\r\n\r\n";
         this->setSendProgress(SendProgress::FINISH);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -758,7 +758,7 @@ Server::run(int fd)
                     if (this->_responses[fd].getReceiveProgress() == ReceiveProgress::ON_GOING)
                     {
                         this->_server_manager->fdClr(fd, FdSet::WRITE);
-                        this->_server_manager->fdSet(this->_responses[fd].getLinkedResourceFd(), FdSet::READ);
+                        this->_server_manager->fdSet(this->_responses[fd].getResourceFd(), FdSet::READ);
                     }
                     if (this->isResponseAllSended(fd))
                     {
@@ -929,7 +929,7 @@ Server::readStaticResource(int resource_fd)
         else
         {
             this->_responses[client_socket].setReceiveProgress(ReceiveProgress::ON_GOING);
-            this->_responses[client_socket].setLinkedResourceFd(resource_fd);
+            this->_responses[client_socket].setResourceFd(resource_fd);
             this->_server_manager->fdClr(resource_fd, FdSet::READ);
             this->_server_manager->fdSet(client_socket, FdSet::WRITE);
         }


### PR DESCRIPTION
Chunked Response의 구조를 변경했습니다.

Sanam님의 커멘트대로 

Static Resource를 읽을 때 읽은 bytes가 BUFFER_SIZE보다 작지 않다면 곧바로 chunked로 응답을 보내야 한다고 판단했습니다.

따라서 그 순간에는 Client Fd의 ReadSet을 Clear하지 않은 채 WriteSet을 세팅시켜줍니다.

Read -> Write -> Read -> Write ..

의 순환을 위해 ReceiveProgress 라는 Enum 클래스를 만들었습니다.