### PR TITLE
Fix/telnet cannot header

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -114,7 +114,7 @@ public:
 
     void setAuthenticateRealm();
 
-    void processIfNotFoundHeaders(int fd, const std::string& readed);
+    void processIfHeadersNotFound(int fd, const std::string& readed);
 
     /* Server run function */
     void acceptClient();

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -114,6 +114,8 @@ public:
 
     void setAuthenticateRealm();
 
+    void processIfNotFoundHeaders(int fd, const std::string& readed);
+
     /* Server run function */
     void acceptClient();
     void openCGIPipe(int fd);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -40,6 +40,7 @@ namespace ft
     std::string inetNtoA(const in_addr_t& client_address);
     void doubleFree(char*** target);
     std::string itosHex(unsigned int n);
+    bool is_print(char ch);
 }
 
 #endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -40,7 +40,7 @@ namespace ft
     std::string inetNtoA(const in_addr_t& client_address);
     void doubleFree(char*** target);
     std::string itosHex(unsigned int n);
-    bool is_print(char ch);
+    bool IsPrintable(char ch);
 }
 
 #endif

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -334,11 +334,6 @@ Server::processIfNotFoundHeaders(int client_fd, const std::string& readed)
     size_t bytes;
     char buf[3];
 
-    if (readed.length() == BUFFER_SIZE)
-    {
-        this->_requests[client_fd].setIsBufferLeft(true);
-        throw (Request::RequestFormatException(this->_requests[client_fd], "400"));
-    }
     if (readed == "\r\n")
     {
         ft::memset(reinterpret_cast<void *>(buf), 0, 3);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -329,16 +329,17 @@ Server::readBufferUntilHeaders(int client_fd, char* buf, size_t header_end_pos)
 }
 
 void
-Server::processIfNotFoundHeaders(int client_fd, const std::string& readed)
+Server::processIfHeadersNotFound(int client_fd, const std::string& readed)
 {
+    const int crlf_size = 2;
     size_t bytes;
-    char buf[3];
+    char buf[crlf_size + 1];
 
     if (readed == "\r\n")
     {
-        ft::memset(reinterpret_cast<void *>(buf), 0, 3);
-        bytes = read(client_fd, buf, 2);
-        if (bytes != 2)
+        ft::memset(reinterpret_cast<void *>(buf), 0, crlf_size + 1);
+        bytes = read(client_fd, buf, crlf_size);
+        if (bytes != crlf_size)
             throw (ReadErrorException());
     }
 }
@@ -369,7 +370,7 @@ Server::receiveRequestWithoutBody(int client_fd)
             this->readBufferUntilHeaders(client_fd, buf, header_end_pos);
         }
         else if ((header_end_pos = readed.find("\r\n")) != std::string::npos)
-            this->processIfNotFoundHeaders(client_fd, readed);
+            this->processIfHeadersNotFound(client_fd, readed);
         else
         {
             //NOTE: if BUFFER_SIZE is too small to read including "\r\n\r\n", this block always execute. 
@@ -528,8 +529,8 @@ Server::sendResponse(const std::string& response_message, int client_fd)
     Log::trace("> sendResponse");
     std::string tmp;
     tmp += response_message;
-    std::cout<<tmp<<std::endl;
-    write(client_fd, tmp.c_str(), tmp.length()); 
+    // std::cout<<tmp<<std::endl;
+    write(client_fd, tmp.c_str(), tmp.length());
     Log::trace("< sendResponse");
     return (true);
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -297,7 +297,7 @@ itosHex(unsigned int n)
 }
 
 bool
-is_print(char ch)
+IsPrintable(char ch)
 {
 	if (ch  >= 32 && ch <= 126)
 		return (true);

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -296,4 +296,12 @@ itosHex(unsigned int n)
     return (result);
 }
 
+bool
+is_print(char ch)
+{
+	if (ch  >= 32 && ch <= 126)
+		return (true);
+	return (false);
+}
+
 }


### PR DESCRIPTION
클라이언트가 `Request line`만 보내는 경우를 처리했습니다.

만약 제대로된 request line 이라면 request를 읽지 않고 다음 select로 넘어가게 됩니다.

request line이 `\r\n`만 있다면 버퍼를 읽음으로써 남아있는 데이터들을 비웁니다.

에러 처리용으로 `is_print` 유틸함수를 구현했으나, 에러 처리는 여기서 하는게 아니라 리퀘스트 라인 valid check 에서 하는 것이라고 판단하고 구현하지 않았습니다.