### PR TITLE
FIX: Check not allowed method request

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -168,9 +168,7 @@ public:
         CannotOpenDirectoryException(Response& res, const std::string& status_code, int error_num);
         virtual const char* what() const throw();
     };
-    class IndexNoExistException : public SendErrorCodeToClientException
-    {
-    private:
+    class IndexNoExistException : public SendErrorCodeToClientException { private:
         Response& _response;
     public:
         IndexNoExistException(Response& response);
@@ -225,6 +223,14 @@ public:
             Response& _response;
         public:
             TargetResourceConflictException(Response& response);
+            virtual const char* what() const throw();
+    };
+    class NotAllowedMethodException : public SendErrorCodeToClientException
+    {
+        private:
+            Response& _response;
+        public:
+            NotAllowedMethodException(Response& response);
             virtual const char* what() const throw();
     };
 };

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -168,7 +168,9 @@ public:
         CannotOpenDirectoryException(Response& res, const std::string& status_code, int error_num);
         virtual const char* what() const throw();
     };
-    class IndexNoExistException : public SendErrorCodeToClientException { private:
+    class IndexNoExistException : public SendErrorCodeToClientException
+    {
+    private:
         Response& _response;
     public:
         IndexNoExistException(Response& response);


### PR DESCRIPTION
요청 `uri` 에 대한 라우트가 설정되면 이후에 요청 method를 해당 라우트의 allowed 메써드와 비교합니다.
만약 허용되지 않은 메써드라면 `405` 에러를 보내게 됩니다.