### PR TITLE
Refactor/receive request chunked body

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -110,7 +110,7 @@ public:
     void appendChunkedBody(char* buf, size_t bytes);
 
     void parseTargetChunkSize(const std::string& chunk_size_line);
-    void parseChunkData(char* buf, size_t bytes, int target_chunk_size);
+    void parseChunkDataAndSetChunkSize(char* buf, size_t bytes, int next_target_chunk_size);
 
     /* Exception */
 public:

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -17,7 +17,6 @@ private:
     std::map<std::string, std::string> _headers;
     std::string _protocol;
     std::string _body;
-    std::string _chunked_body;
     std::string _status_code;
     ReqInfo _info;
     bool _is_buffer_left;
@@ -53,7 +52,6 @@ public:
     const std::string& getAuthType() const;
     const std::string& getRemoteUser() const;
     const std::string& getRemoteIdent() const;
-    const std::string& getChunkedBody() const;
     int getTargetChunkSize() const;
 
     /* Setter */
@@ -71,7 +69,6 @@ public:
     void setAuthType(const std::string& auth_type);
     void setRemoteUser(const std::string& remote_user);
     void setRemoteIdent(const std::string& remote_ident);
-    void setChunkedBody(const std::string& chunked_body);
     void setTargetChunkSize(const int target_size);
 
     /* Util */
@@ -93,7 +90,6 @@ public:
     void parseRequestWithoutBody(char* buf);
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
-    void parseChunkedBody(const std::string& body);
 
     /* valid check */
     bool isValidLine(std::vector<std::string>& request_line);
@@ -107,7 +103,6 @@ public:
     bool isDuplicatedHeader(std::string& key);
 
     void appendBody(char* buf, int bytes);
-    void appendChunkedBody(char* buf, size_t bytes);
 
     void parseTargetChunkSize(const std::string& chunk_size_line);
     void parseChunkDataAndSetChunkSize(char* buf, size_t bytes, int next_target_chunk_size);

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -108,6 +108,9 @@ public:
 
     void appendBody(char* buf, int bytes);
     void appendChunkedBody(char* buf, size_t bytes);
+
+    void parseTargetChunkSize(const std::string& chunk_size_line);
+
     /* Exception */
 public:
     class RequestFormatException : public std::exception

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -110,6 +110,7 @@ public:
     void appendChunkedBody(char* buf, size_t bytes);
 
     void parseTargetChunkSize(const std::string& chunk_size_line);
+    void parseChunkData(char* buf, size_t bytes, int target_chunk_size);
 
     /* Exception */
 public:

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -133,8 +133,7 @@ public:
     bool isCGIReadPipe(int fd) const;
     bool isCGIWritePipe(int fd) const;
 
-    void receiveChunkSize(int fd);
-    void receiveChunkData(int client_fd, int receive_size, int target_chunk_size);
+    void receiveChunkSize(int fd, size_t index_of_crlf);
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -22,6 +22,8 @@ const int BUFFER_SIZE = 6553600;
 const int RECEIVE_SOCKET_STREAM_SIZE = 254560;
 const int SEND_PIPE_STREAM_SIZE = 65536;
 const int CHUNKED_LINE_LENGTH = 65536;
+const int DEFAULT_TARGET_CHUNK_SIZE = -1;
+const int CRLF_SIZE = 2;
 const int NUM_OF_META_VARIABLES = 18;
 
 class ServerManager;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -134,6 +134,7 @@ public:
     bool isCGIWritePipe(int fd) const;
 
     void receiveChunkSize(int fd, size_t index_of_crlf);
+    void receiveChunkData(int client_fd, int receive_size, int target_chunk_size);
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -20,6 +20,7 @@
 
 const int BUFFER_SIZE = 6553600;
 const int RECEIVE_SOCKET_STREAM_SIZE = 254560;
+const int SEND_PIPE_STREAM_SIZE = 65536;
 const int CHUNKED_LINE_LENGTH = 65536;
 const int NUM_OF_META_VARIABLES = 18;
 
@@ -131,6 +132,9 @@ public:
 
     bool isCGIReadPipe(int fd) const;
     bool isCGIWritePipe(int fd) const;
+
+    void receiveChunkSize(int fd);
+    void receiveChunkData(int client_fd, int receive_size, int target_chunk_size);
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -129,8 +129,8 @@ public:
     bool makeEnvpUsingEtc(char** envp, int fd, int* idx);
     bool isResponseAllSended(int fd) const;
 
-bool isCGIReadPipe(int fd) const;
-bool isCGIWritePipe(int fd) const;
+    bool isCGIReadPipe(int fd) const;
+    bool isCGIWritePipe(int fd) const;
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -218,19 +218,24 @@ public:
     };
     class CannotPutOnDirectoryException : public SendErrorCodeToClientException
     {
-        private:
-            Response& _response;
-        public:
-            CannotPutOnDirectoryException(Response& response);
-            virtual const char* what() const throw();
+    private:
+        Response& _response;
+    public:
+        CannotPutOnDirectoryException(Response& response);
+        virtual const char* what() const throw();
     };
     class TargetResourceConflictException : public SendErrorCodeToClientException
     {
-        private:
-            Response& _response;
-        public:
-            TargetResourceConflictException(Response& response);
-            virtual const char* what() const throw();
+    private:
+        Response& _response;
+    public:
+        TargetResourceConflictException(Response& response);
+        virtual const char* what() const throw();
+    };
+    class UnchunkedErrorException : public SendErrorCodeToClientException
+    {
+    public:
+        virtual const char* what() const throw();
     };
 };
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -137,6 +137,7 @@ public:
 
     void receiveChunkSize(int fd, size_t index_of_crlf);
     void receiveChunkData(int client_fd, int receive_size, int target_chunk_size);
+    void receiveLastChunkData(int fd);
 
 public:
     class PayloadTooLargeException : public std::exception

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -416,6 +416,17 @@ Request::parseHeaders(std::string& req_message)
 }
 
 void
+Request::parseTargetChunkSize(const std::string& chunk_size_line)
+{
+    int target_chunk_size;
+    
+    target_chunk_size = ft::stoiHex(chunk_size_line);
+    if (target_chunk_size == -1)
+        throw (RequestFormatException(*this));
+    this->setTargetChunkSize(target_chunk_size);
+}
+
+void
 Request::parseChunkedBody(const std::string& body)
 {
     int line_len = 0;

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -427,13 +427,13 @@ Request::parseTargetChunkSize(const std::string& chunk_size_line)
 }
 
 void
-Request::parseChunkData(char* buf, size_t bytes, int target_chunk_size)
+Request::parseChunkDataAndSetChunkSize(char* buf, size_t bytes, int next_target_chunk_size)
 {
-    this->setTargetChunkSize(target_chunk_size);
     if (bytes == RECEIVE_SOCKET_STREAM_SIZE)
         this->appendBody(buf, bytes);
     else
         this->appendBody(buf, bytes - 2);
+    this->setTargetChunkSize(next_target_chunk_size);
 }
 
 void

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -427,6 +427,16 @@ Request::parseTargetChunkSize(const std::string& chunk_size_line)
 }
 
 void
+Request::parseChunkData(char* buf, size_t bytes, int target_chunk_size)
+{
+    this->setTargetChunkSize(target_chunk_size);
+    if (bytes == RECEIVE_SOCKET_STREAM_SIZE)
+        this->appendBody(buf, bytes);
+    else
+        this->appendBody(buf, bytes - 2);
+}
+
+void
 Request::parseChunkedBody(const std::string& body)
 {
     int line_len = 0;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -784,10 +784,6 @@ Server::acceptClient()
     Log::trace("< acceptClient");
 }
 
-//TODO: URI가 CGI라면 Request Body를 바로 CGI한테 보내줘도 되지 않을까?
-//TODO: Chunked로 CGI왔을 때도 꼭 테스트 해보기....
-//TODO: CGI 요청이 chunked로 올 수도 있음. 이 때에는 content-Length로 비교할 수 없다.
-
 void
 Server::sendDataToCGI(int write_fd_to_cgi)
 {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -849,8 +849,6 @@ Server::acceptClient()
     Log::trace("< acceptClient");
 }
 
-int transfered;
-
 void
 Server::sendDataToCGI(int write_fd_to_cgi)
 {
@@ -947,8 +945,6 @@ Server::receiveDataFromCGI(int read_fd_from_cgi)
     Log::trace("< receiveDataFromCGI");
 }
 
-int wrote_bytes;
-
 void
 Server::putFileOnServer(int resource_fd)
 {
@@ -962,15 +958,11 @@ Server::putFileOnServer(int resource_fd)
     if (BUFFER_SIZE > remained)
     {
         bytes = write(resource_fd, &(body.c_str()[transfered_body_size]), remained);
-        wrote_bytes += bytes;
-        std::cout<<"\033[1;30;43m"<<"wrote_bytes: "<<wrote_bytes<<"\033[0m"<<std::endl;
         this->closeFdAndSetFd(resource_fd, FdSet::WRITE, client_fd, FdSet::WRITE);
     }
     else
     {
         bytes = write(resource_fd, &(body.c_str()[transfered_body_size]), BUFFER_SIZE);
-        wrote_bytes += bytes;
-        std::cout<<"\033[1;30;43m"<<"wrote_bytes: "<<wrote_bytes<<"\033[0m"<<std::endl;
         transfered_body_size += bytes;
         request.setTransferedBodySize(transfered_body_size);
     }
@@ -1232,11 +1224,7 @@ Server::openStaticResource(int client_fd)
     {
         resource_fd = open(path.c_str(), O_CREAT | O_RDWR, 0666);
         if (resource_fd < 0)
-        {
-            std::cout<<"\033[1;37;41m"<<"Open error in openStaticResource"<<"\033[0m"<<std::endl;
-            std::cout<<"\033[1;30;43m"<<"Path: "<<path.c_str()<<"\033[0m"<<std::endl;
             throw InternalServerException(this->_responses[client_fd]);
-        }
         // resource_fd = open("/Users/sanam/Desktop/Webserv/abcd", O_CREAT | O_RDWR, 0666);
         // 여기서 파일이 오픈되지 않는다는 건 상위 폴더 자체가 없다는 것.
         // 409 에러를 보내줄 수 있게 만들자

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -454,10 +454,7 @@ Server::receiveRequestChunkedBody(int client_fd)
             if ((index = std::string(buf).find("\r\n")) != std::string::npos)
             {
                 if ((bytes = recv(client_fd, buf, index + 2, 0)) > 0)
-                {
-                    int line_len = ft::stoiHex(std::string(buf).substr(0, index));
-                    request.setTargetChunkSize(line_len);
-                }
+                    request.parseTargetChunkSize(buf);
                 else if (bytes == 0)
                     this->closeClientSocket(client_fd);
                 else
@@ -465,6 +462,10 @@ Server::receiveRequestChunkedBody(int client_fd)
                     //TODO: 에러 객체 변경하기
                     throw (ReadErrorException());
                 }
+            }
+            else
+            {
+                //TODO: 예외처리하기
             }
         }
         else if (request.getTargetChunkSize() == 0)
@@ -492,10 +493,7 @@ Server::receiveRequestChunkedBody(int client_fd)
             if (request.getTargetChunkSize() < RECEIVE_SOCKET_STREAM_SIZE)
             {
                 if ((bytes = recv(client_fd, buf, request.getTargetChunkSize() + 2, 0)) > 0)
-                {
-                    request.setTargetChunkSize(-1);
-                    request.appendBody(buf, bytes);
-                }
+                    request.parseChunkDataAndSetChunkSize(buf, bytes, -1);
                 else if (bytes == 0)
                     this->closeClientSocket(client_fd);
                 else
@@ -505,10 +503,7 @@ Server::receiveRequestChunkedBody(int client_fd)
             else
             {
                 if ((bytes = recv(client_fd, buf, RECEIVE_SOCKET_STREAM_SIZE, 0)) > 0)
-                {
-                    request.setTargetChunkSize(request.getTargetChunkSize() - RECEIVE_SOCKET_STREAM_SIZE);
-                    request.appendBody(buf, bytes);
-                }
+                    request.parseChunkDataAndSetChunkSize(buf, bytes, request.getTargetChunkSize() - RECEIVE_SOCKET_STREAM_SIZE);
                 else if (bytes == 0)
                     this->closeClientSocket(client_fd);
                 else

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1114,10 +1114,7 @@ Server::readStaticResource(int resource_fd)
         }
     }
     else if (bytes == 0)
-    {
         this->closeFdAndSetFd(resource_fd, FdSet::READ, client_socket, FdSet::WRITE);
-        // throw (ReadErrorException());
-    }
     else
     {
         this->closeFdAndSetFd(resource_fd, FdSet::READ, client_socket, FdSet::WRITE);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -843,8 +843,6 @@ Server::sendDataToCGI(int write_fd_to_cgi)
     Log::trace("< sendDataToCGI");
 }
 
-//TODO: buf를 동적할당 구조 변경해주기 - 안했을 시 매우 큰 payload를 감당하지 못함.
-//NOTE: 멤버 변수로 만들어서 처음 딱 한번만 할당하고 마지막에 할당 해제 해주게 수정하기.
 void
 Server::receiveDataFromCGI(int read_fd_from_cgi)
 {


### PR DESCRIPTION
receiveRequestChunkedBody 함수를 Refactoring 하였습니다.

1. receiveChunkSize
2. receiveChunkData
3. receiveLastChunkData

세 개의 함수로 나누고,

UnchunkedErrorException 예외클래스를 생성하였습니다.

또한 Request의 멤버변수 _chunked_body와 관련 함수들(GETTER/SETTER, appendChunkedBody, parseChunkedBody)은 더 이상 사용하지 않기 때문에 모두 제거했습니다.
