### PR TITLE
Fix/process if headers not found

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -22,8 +22,8 @@ private:
     std::string _status_code;
     ReqInfo _info;
     bool _is_buffer_left;
-    std::string _ip_address;
     int _transfered_body_size;
+    std::string _ip_address;
     std::string _remote_user;
     std::string _remote_ident;
     std::string _auth_type;
@@ -32,6 +32,7 @@ private:
 
     int _recv_counts;
     bool _carriege_return_trimmed;
+    std::string _temp_buffer;
 
 public:
     /* Constructor */
@@ -64,6 +65,11 @@ public:
     bool getCarriegeReturnTrimmed() const;
 
     int getReceiveCounts() const;
+    const std::string& getTempBuffer() const;
+
+/*============================================================================*/
+/********************************  Setter  ************************************/
+/*============================================================================*/
 
     /* Setter */
     void setMethod(const std::string& method);
@@ -85,6 +91,7 @@ public:
 
     void setReceiveCounts(const int recv_count);
     void setCarriegeReturnTrimmed(const bool trimmed);
+    void setTempBuffer(const std::string& temp_body);
 
     /* Util */
 
@@ -103,6 +110,7 @@ public:
 
     /* parser */
     void parseRequestWithoutBody(char* buf, int bytes);
+    void parseRequestWithoutBody();
     bool parseRequestLine(std::string& req_message);
     bool parseHeaders(std::string& req_message);
 
@@ -125,6 +133,7 @@ public:
     void parseTargetChunkSize(const std::string& chunk_size_line);
     void parseChunkDataAndSetChunkSize(char* buf, size_t bytes, int next_target_chunk_size);
     void parseChunkData(char* buf, size_t bytes);
+    void appendTempBuffer(char* buf, size_t bytes);
 
     /* Exception */
 public:


### PR DESCRIPTION
20 * 5000 에서 테스터를 강제종료 하면 가끔 무한반복에 빠지는 문제를 해결(?) 했습니다.

무한반복에 빠지던 이유는 강제 종료 하는 순간에 클라이언트 소켓이 서버에 Request 를 보냈는데

보낸 요청이 완벽한 요청(`\r\n\r\n`) 이 아니라서 서버가 버퍼에서 요청을 지우지 않고 recv-MSG_PEEK 만 하고있었기 때문입니다.
(클라이언트가 연결을 끊어도 스트림은 비워지지 않습니다)

따라서  버퍼를 비워야 할 필요가 있었고 이를 위해 완벽하지 않은 request가 왔을 때 버퍼를 읽고 저장할 변수 `_temp_buffer`를 만들었습니다.