### PR TITLE
Refactor/read and write

### DIFF
--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -40,7 +40,7 @@ public:
     static std::string fdTypeToString(const FdType& type);
     static std::string reqInfoToString(const ReqInfo& req_info);
     static std::string resTypeToString(const ResType& type);
-    static std::string sendProgressToString(const SendProgress& progress);
+    static std::string parseProgressToString(const ParseProgress& progress);
     static void printLocationConfig(const std::map<std::string, location_info>& loc_config);
     static void printLocationInfo(const location_info& loc_info);
 

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -44,6 +44,8 @@ private:
     ReceiveProgress _receive_progress;
 
     int _resoure_fd;
+    int _sended_response_size;
+    std::string _response_message;
 
 public:
     /* Constructor */
@@ -86,6 +88,8 @@ public:
 
     int getResourceFd() const;
     const std::map<std::string, std::string>& getHeaders() const;
+    int getSendedResponseSize() const;
+    const std::string& getResponseMessage() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
@@ -109,6 +113,8 @@ public:
     void setSendProgress(const SendProgress send_progress);
     void setReceiveProgress(const ReceiveProgress rececive_progress);
     void setResourceFd(const int resource_fd);
+    void setSendedResponseSize(const int sended_response_size);
+    void setResponseMessage(const std::string& response_message);
 
     /* Exception */
 public:

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -46,7 +46,7 @@ private:
     int _resoure_fd;
     int _sended_response_size;
     std::string _response_message;
-    ResInfo _res_info;
+    SendProgress _send_progress;
 
 public:
     /* Constructor */
@@ -91,7 +91,7 @@ public:
     const std::map<std::string, std::string>& getHeaders() const;
     int getSendedResponseSize() const;
     const std::string& getResponseMessage() const;
-    const ResInfo& getResInfo() const;
+    const SendProgress& getSendProgress() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
@@ -117,7 +117,7 @@ public:
     void setResourceFd(const int resource_fd);
     void setSendedResponseSize(const int sended_response_size);
     void setResponseMessage(const std::string& response_message);
-    void setResInfo(const ResInfo& res_info);
+    void setSendProgress(const SendProgress& send_progress);
 
     /* Exception */
 public:

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -46,6 +46,7 @@ private:
     int _resoure_fd;
     int _sended_response_size;
     std::string _response_message;
+    ResInfo _res_info;
 
 public:
     /* Constructor */
@@ -90,6 +91,7 @@ public:
     const std::map<std::string, std::string>& getHeaders() const;
     int getSendedResponseSize() const;
     const std::string& getResponseMessage() const;
+    const ResInfo& getResInfo() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
@@ -115,6 +117,7 @@ public:
     void setResourceFd(const int resource_fd);
     void setSendedResponseSize(const int sended_response_size);
     void setResponseMessage(const std::string& response_message);
+    void setResInfo(const ResInfo& res_info);
 
     /* Exception */
 public:

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -40,7 +40,7 @@ private:
     //TODO: 생성자에 추가하기.
     size_t _already_encoded_size;
 
-    SendProgress _send_progress;
+    ParseProgress _parse_progress;
     ReceiveProgress _receive_progress;
 
     int _resoure_fd;
@@ -84,7 +84,7 @@ public:
     const std::string& getTransmittingBody() const;
 
     size_t getAlreadyEncodedSize() const;
-    const SendProgress& getSendProgress() const;
+    const ParseProgress& getParseProgress() const;
     const ReceiveProgress& getReceiveProgress() const;
 
     int getResourceFd() const;
@@ -112,7 +112,7 @@ public:
     void setCGIPid(const int pid);
 
     void setAlreadyEncodedSize(const size_t already_encoded_size);
-    void setSendProgress(const SendProgress send_progress);
+    void setParseProgress(const ParseProgress sparseprogress);
     void setReceiveProgress(const ReceiveProgress rececive_progress);
     void setResourceFd(const int resource_fd);
     void setSendedResponseSize(const int sended_response_size);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -98,8 +98,8 @@ public:
     void receiveRequestNormalBody(int fd);
     void receiveRequestChunkedBody(int fd);
     void clearRequestBuffer(int fd);
-    std::string makeResponseMessage(int fd);
-    void sendResponse(const std::string& response_meesage, int fd);
+    void makeResponseMessage(int fd);
+    void sendResponse(int fd);
     bool isClientOfServer(int fd) const;
     bool isIndexFileExist(int fd);
     void findResourceAbsPath(int fd);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -97,7 +97,6 @@ public:
     void readBufferUntilHeaders(int fd, char* buf, size_t header_end_pos);
     void receiveRequestNormalBody(int fd);
     void receiveRequestChunkedBody(int fd);
-    void clearRequestBuffer(int fd);
     void makeResponseMessage(int fd);
     void sendResponse(int fd);
     bool isClientOfServer(int fd) const;

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -64,7 +64,6 @@ enum class ReqInfo
     COMPLETE,
     NORMAL_BODY,
     CHUNKED_BODY,
-    MUST_CLEAR,
 };
 
 enum class ResInfo

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -66,13 +66,6 @@ enum class ReqInfo
     CHUNKED_BODY,
 };
 
-enum class ResInfo
-{
-    READY,
-    SENDING,
-    ALL_SENDED,
-};
-
 enum class ResType
 {
     NOT_YET_CHECKED,
@@ -83,7 +76,14 @@ enum class ResType
     ERROR_HTML,
 };
 
-enum class SendProgress
+enum class ResInfo
+{
+    READY,
+    SENDING,
+    ALL_SENDED,
+};
+
+enum class ParseProgress
 {
     DEFAULT,
     CHUNK_START,

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -76,7 +76,7 @@ enum class ResType
     ERROR_HTML,
 };
 
-enum class ResInfo
+enum class SendProgress
 {
     READY,
     SENDING,

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -67,6 +67,13 @@ enum class ReqInfo
     MUST_CLEAR,
 };
 
+enum class ResInfo
+{
+    READY,
+    SENDING,
+    ALL_SENDED,
+};
+
 enum class ResType
 {
     NOT_YET_CHECKED,

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -277,9 +277,6 @@ Log::reqInfoToString(const ReqInfo& req_info)
     case ReqInfo::CHUNKED_BODY:
         return ("CHUNKED_BODY");
 
-    case ReqInfo::MUST_CLEAR:
-        return ("MUST_CLEAR");
-
     default:
         return ("NOT YET REGISTED IN reqInfoToString");
         break;

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -284,20 +284,20 @@ Log::reqInfoToString(const ReqInfo& req_info)
 }
 
 std::string
-Log::sendProgressToString(const SendProgress& progress)
+Log::parseProgressToString(const ParseProgress& progress)
 {
     switch (progress)
     {
-    case SendProgress::DEFAULT:
+    case ParseProgress::DEFAULT:
         return ("DEFAULT");
 
-    case SendProgress::CHUNK_START:
+    case ParseProgress::CHUNK_START:
         return ("CHUNK_START");
 
-    case SendProgress::CHUNK_PROGRESS:
+    case ParseProgress::CHUNK_PROGRESS:
         return ("CHUNK_PROGRESS");
 
-    case SendProgress::FINISH:
+    case ParseProgress::FINISH:
         return ("FINISH");
 
     default:

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -328,7 +328,7 @@ Request::updateReqInfo()
     if (this->getMethod() == "" && this->getUri() == "" && this->getVersion() == "")
         this->setReqInfo(ReqInfo::READY);
     else if (this->isBodyUnnecessary())
-        this->setReqInfo(ReqInfo::MUST_CLEAR);
+        throw (RequestFormatException(*this, "400"));
     else if (this->isNormalBody())
         this->setReqInfo(ReqInfo::NORMAL_BODY);
     else if (this->isChunkedBody())

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -247,8 +247,8 @@ Response::getResponseMessage() const
     return (this->_response_message);
 }
 
-const
-Response::ResInfo& getResInfo() const
+const ResInfo&
+Response::getResInfo() const
 {
     return (this->_res_info);
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -21,7 +21,7 @@ _location_info(), _resource_abs_path(""), _route(""),
 _directory_entry(""), _resource_type(ResType::NOT_YET_CHECKED), _body(""),
 _stdin_of_cgi(DEFAULT_FD), _stdout_of_cgi(DEFAULT_FD), _read_fd_from_cgi(DEFAULT_FD),
 _write_fd_to_cgi(DEFAULT_FD),  _cgi_pid(DEFAULT_FD), _uri_path(""), _uri_extension(""), _transmitting_body(""),
-_already_encoded_size(0), _send_progress(SendProgress::DEFAULT),
+_already_encoded_size(0), _parse_progress(ParseProgress::DEFAULT),
 _receive_progress(ReceiveProgress::DEFAULT), _resoure_fd(DEFAULT_FD),
 _sended_response_size(0), _response_message(""), _res_info(ResInfo::READY)
 {
@@ -41,7 +41,7 @@ _body(other._body), _stdin_of_cgi(other._stdout_of_cgi),
 _stdout_of_cgi(other._stdout_of_cgi), _read_fd_from_cgi(other._read_fd_from_cgi),
 _write_fd_to_cgi(other._write_fd_to_cgi), _cgi_pid(other._cgi_pid),
 _uri_path(other._uri_path), _uri_extension(other._uri_extension), _transmitting_body(other._transmitting_body),
-_already_encoded_size(other._already_encoded_size), _send_progress(other._send_progress),
+_already_encoded_size(other._already_encoded_size), _parse_progress(other._parse_progress),
 _receive_progress(other._receive_progress), _resoure_fd(other._resoure_fd),
 _sended_response_size(other._sended_response_size), _response_message(other._response_message),
 _res_info(other._res_info)
@@ -84,7 +84,7 @@ Response::operator=(const Response& rhs)
     this->_uri_extension = rhs._uri_extension;
     this->_transmitting_body = rhs._transmitting_body;
     this->_already_encoded_size = rhs._already_encoded_size;
-    this->_send_progress = rhs._send_progress;
+    this->_parse_progress = rhs._parse_progress;
     this->_receive_progress = rhs._receive_progress;
     this->_resoure_fd = rhs._resoure_fd;
     this->_sended_response_size = rhs._sended_response_size;
@@ -211,10 +211,10 @@ Response::getTransmittingBody() const
     return (this->_transmitting_body);
 }
 
-const SendProgress&
-Response::getSendProgress() const
+const ParseProgress&
+Response::getParseProgress() const
 {
-    return (this->_send_progress);
+    return (this->_parse_progress);
 }
 
 const ReceiveProgress&
@@ -356,9 +356,9 @@ Response::setAlreadyEncodedSize(const size_t already_encoded_size)
 }
 
 void
-Response::setSendProgress(const SendProgress send_progress)
+Response::setParseProgress(const ParseProgress parse_progress)
 {
-    this->_send_progress = send_progress;
+    this->_parse_progress = parse_progress;
 }
 
 void
@@ -452,7 +452,7 @@ Response::init()
     this->_uri_extension = "";
     this->_transmitting_body = "";
     this->_already_encoded_size = 0;
-    this->_send_progress = SendProgress::DEFAULT;
+    this->_parse_progress = ParseProgress::DEFAULT;
     this->_receive_progress = ReceiveProgress::DEFAULT;
     this->_resoure_fd = DEFAULT_FD;
     this->_sended_response_size = 0;
@@ -1223,15 +1223,15 @@ Response::encodeChunkedBody()
         chunked_body += "\r\n";
         already_encoded_size += substring_size;
     }
-    if (this->getSendProgress() == SendProgress::DEFAULT)
-        this->setSendProgress(SendProgress::CHUNK_START);
-    else if (this->getSendProgress() == SendProgress::CHUNK_START)
-        this->setSendProgress(SendProgress::CHUNK_PROGRESS);
+    if (this->getParseProgress() == ParseProgress::DEFAULT)
+        this->setParseProgress(ParseProgress::CHUNK_START);
+    else if (this->getParseProgress() == ParseProgress::CHUNK_START)
+        this->setParseProgress(ParseProgress::CHUNK_PROGRESS);
     if (already_encoded_size == raw_body_size && 
                 this->getReceiveProgress() == ReceiveProgress::FINISH)
     {
         chunked_body += "0\r\n\r\n";
-        this->setSendProgress(SendProgress::FINISH);
+        this->setParseProgress(ParseProgress::FINISH);
     }
 
     this->setAlreadyEncodedSize(already_encoded_size);

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -22,7 +22,8 @@ _directory_entry(""), _resource_type(ResType::NOT_YET_CHECKED), _body(""),
 _stdin_of_cgi(DEFAULT_FD), _stdout_of_cgi(DEFAULT_FD), _read_fd_from_cgi(DEFAULT_FD),
 _write_fd_to_cgi(DEFAULT_FD),  _cgi_pid(DEFAULT_FD), _uri_path(""), _uri_extension(""), _transmitting_body(""),
 _already_encoded_size(0), _send_progress(SendProgress::DEFAULT),
-_receive_progress(ReceiveProgress::DEFAULT), _resoure_fd(DEFAULT_FD)
+_receive_progress(ReceiveProgress::DEFAULT), _resoure_fd(DEFAULT_FD),
+_sended_response_size(0), _response_message(""), _res_info(ResInfo::READY)
 {
     ft::memset(&this->_file_info, 0, sizeof(this->_file_info));
     this->initStatusCodeTable();
@@ -41,7 +42,9 @@ _stdout_of_cgi(other._stdout_of_cgi), _read_fd_from_cgi(other._read_fd_from_cgi)
 _write_fd_to_cgi(other._write_fd_to_cgi), _cgi_pid(other._cgi_pid),
 _uri_path(other._uri_path), _uri_extension(other._uri_extension), _transmitting_body(other._transmitting_body),
 _already_encoded_size(other._already_encoded_size), _send_progress(other._send_progress),
-_receive_progress(other._receive_progress), _resoure_fd(other._resoure_fd)
+_receive_progress(other._receive_progress), _resoure_fd(other._resoure_fd),
+_sended_response_size(other._sended_response_size), _response_message(other._response_message),
+_res_info(other._res_info)
 {}
 
 /*============================================================================*/
@@ -84,6 +87,9 @@ Response::operator=(const Response& rhs)
     this->_send_progress = rhs._send_progress;
     this->_receive_progress = rhs._receive_progress;
     this->_resoure_fd = rhs._resoure_fd;
+    this->_sended_response_size = rhs._sended_response_size;
+    this->_response_message = rhs._response_message;
+    this->_res_info = rhs._res_info;
     return (*this);
 }
 
@@ -449,6 +455,9 @@ Response::init()
     this->_send_progress = SendProgress::DEFAULT;
     this->_receive_progress = ReceiveProgress::DEFAULT;
     this->_resoure_fd = DEFAULT_FD;
+    this->_sended_response_size = 0;
+    this->_response_message = "";
+    this->_res_info = ResInfo::READY;
     //NOTE: _status_code_table, _mime_type_table은 초기화 대상 아님. 값이 바뀌지 않으며 초기화시 성능저하 우려되기 때문.
 }
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -241,6 +241,12 @@ Response::getResponseMessage() const
     return (this->_response_message);
 }
 
+const
+Response::ResInfo& getResInfo() const
+{
+    return (this->_res_info);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -377,6 +383,12 @@ void
 Response::setResponseMessage(const std::string& response_message)
 {
     this->_response_message = response_message;
+}
+
+void
+Response::setResInfo(const ResInfo& res_info)
+{
+    this->_res_info = res_info;
 }
 
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -229,6 +229,18 @@ Response::getHeaders() const
     return (this->_headers);
 }
 
+int
+Response::getSendedResponseSize() const
+{
+    return (this->_sended_response_size);
+}
+
+const std::string&
+Response::getResponseMessage() const
+{
+    return (this->_response_message);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -353,6 +365,18 @@ void
 Response::setHeaders(const std::string& key, const std::string& value)
 {
     this->_headers[key] = value;
+}
+
+void
+Response::setSendedResponseSize(const int sended_response_size)
+{
+    this->_sended_response_size = sended_response_size;
+}
+
+void
+Response::setResponseMessage(const std::string& response_message)
+{
+    this->_response_message = response_message;
 }
 
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -23,7 +23,7 @@ _stdin_of_cgi(DEFAULT_FD), _stdout_of_cgi(DEFAULT_FD), _read_fd_from_cgi(DEFAULT
 _write_fd_to_cgi(DEFAULT_FD),  _cgi_pid(DEFAULT_FD), _uri_path(""), _uri_extension(""), _transmitting_body(""),
 _already_encoded_size(0), _parse_progress(ParseProgress::DEFAULT),
 _receive_progress(ReceiveProgress::DEFAULT), _resoure_fd(DEFAULT_FD),
-_sended_response_size(0), _response_message(""), _res_info(ResInfo::READY)
+_sended_response_size(0), _response_message(""), _send_progress(SendProgress::READY)
 {
     ft::memset(&this->_file_info, 0, sizeof(this->_file_info));
     this->initStatusCodeTable();
@@ -44,7 +44,7 @@ _uri_path(other._uri_path), _uri_extension(other._uri_extension), _transmitting_
 _already_encoded_size(other._already_encoded_size), _parse_progress(other._parse_progress),
 _receive_progress(other._receive_progress), _resoure_fd(other._resoure_fd),
 _sended_response_size(other._sended_response_size), _response_message(other._response_message),
-_res_info(other._res_info)
+_send_progress(other._send_progress)
 {}
 
 /*============================================================================*/
@@ -89,7 +89,7 @@ Response::operator=(const Response& rhs)
     this->_resoure_fd = rhs._resoure_fd;
     this->_sended_response_size = rhs._sended_response_size;
     this->_response_message = rhs._response_message;
-    this->_res_info = rhs._res_info;
+    this->_send_progress = rhs._send_progress;
     return (*this);
 }
 
@@ -247,10 +247,10 @@ Response::getResponseMessage() const
     return (this->_response_message);
 }
 
-const ResInfo&
-Response::getResInfo() const
+const SendProgress&
+Response::getSendProgress() const
 {
-    return (this->_res_info);
+    return (this->_send_progress);
 }
 
 /*============================================================================*/
@@ -392,9 +392,9 @@ Response::setResponseMessage(const std::string& response_message)
 }
 
 void
-Response::setResInfo(const ResInfo& res_info)
+Response::setSendProgress(const SendProgress& send_progress)
 {
-    this->_res_info = res_info;
+    this->_send_progress = send_progress;
 }
 
 /*============================================================================*/
@@ -457,7 +457,7 @@ Response::init()
     this->_resoure_fd = DEFAULT_FD;
     this->_sended_response_size = 0;
     this->_response_message = "";
-    this->_res_info = ResInfo::READY;
+    this->_send_progress = SendProgress::READY;
     //NOTE: _status_code_table, _mime_type_table은 초기화 대상 아님. 값이 바뀌지 않으며 초기화시 성능저하 우려되기 때문.
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1233,8 +1233,8 @@ Server::run(int fd)
                     this->sendDataToCGI(fd);
                 else if (this->isClientSocket(fd))
                 {
-                    std::string response_message = this->makeResponseMessage(fd);
-                    this->sendResponse(response_message, fd);
+                    this->makeResponseMessage(fd);
+                    this->sendResponse(fd);
                     if (this->_responses[fd].getReceiveProgress() == ReceiveProgress::ON_GOING)
                     {
                         this->_server_manager->fdClr(fd, FdSet::WRITE);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -718,10 +718,10 @@ Server::makeResponseMessage(int client_fd)
     status_line = response.makeStatusLine();
 
     //TODO: refactoring
-    const SendProgress& send_progress = response.getSendProgress();
-    switch (send_progress)
+    const ParseProgress& parse_progress = response.getParseProgress();
+    switch (parse_progress)
     {
-    case SendProgress::FINISH:
+    case ParseProgress::FINISH:
         if (method == "HEAD")
             response.setResponseMessage("");
 
@@ -729,8 +729,8 @@ Server::makeResponseMessage(int client_fd)
         Log::trace("< makeResponseMessage", 1);
         response.setResponseMessage(response.getTransmittingBody());
         break;
-    case SendProgress::DEFAULT:
-        response.setSendProgress(SendProgress::FINISH);
+    case ParseProgress::DEFAULT:
+        response.setParseProgress(ParseProgress::FINISH);
         if (method == "HEAD" || ((method == "PUT" || method == "DELETE") && response.getStatusCode().front() == '2'))
             response.setResponseMessage(status_line + headers);
 
@@ -738,7 +738,7 @@ Server::makeResponseMessage(int client_fd)
         Log::trace("< makeResponseMessage", 1);
         response.setResponseMessage(status_line + headers + response.getTransmittingBody());
         break;
-    case SendProgress::CHUNK_START:
+    case ParseProgress::CHUNK_START:
         if (request.getMethod() == "HEAD")
             response.setResponseMessage(status_line + headers);
             
@@ -746,7 +746,7 @@ Server::makeResponseMessage(int client_fd)
         Log::trace("< makeResponseMessage", 1);
         response.setResponseMessage(status_line + headers + response.getTransmittingBody());
         break;
-    case SendProgress::CHUNK_PROGRESS:
+    case ParseProgress::CHUNK_PROGRESS:
         if (request.getMethod() == "HEAD")
             response.setResponseMessage("");
 
@@ -784,7 +784,7 @@ Server::sendResponse(int client_fd)
         sended_bytes += bytes;
         // std::cout<<response_message<<std::endl;
         std::cout<<"\033[1;44;37m"<<"sended_bytes: "<<sended_bytes<<"\033[0m"<<std::endl;
-        std::cout<<"\033[1;44;37m"<<"SendProgress: "<<Log::sendProgressToString(this->_responses[client_fd].getSendProgress())<<"\033[0m"<<std::endl;
+        std::cout<<"\033[1;44;37m"<<"ParseProgress: "<<Log::parseProgressToString(this->_responses[client_fd].getParseProgress())<<"\033[0m"<<std::endl;
 
         sended_response_size += bytes;
         response.setSendedResponseSize(sended_response_size);
@@ -1919,7 +1919,7 @@ Server::makeCGIArgv(int client_fd)
 bool
 Server::isResponseAllSended(int fd) const
 {
-    return (this->_responses[fd].getSendProgress() == SendProgress::FINISH &&
+    return (this->_responses[fd].getParseProgress() == ParseProgress::FINISH &&
             this->_responses[fd].getResInfo() == ResInfo::ALL_SENDED);
 }
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -790,12 +790,12 @@ Server::sendResponse(int client_fd)
         response.setSendedResponseSize(sended_response_size);
         if (sended_response_size == response_message_size)
         {
-            response.setResInfo(ResInfo::ALL_SENDED);
+            response.setSendProgress(SendProgress::ALL_SENDED);
             response.setSendedResponseSize(0);
             response.setResponseMessage("");
         }
         else
-            response.setResInfo(ResInfo::SENDING);
+            response.setSendProgress(SendProgress::SENDING);
     }
     else if (bytes == 0)
         throw (CannotWriteToClientException());
@@ -1189,7 +1189,7 @@ Server::run(int fd)
                     this->sendDataToCGI(fd);
                 else if (this->isClientSocket(fd))
                 {
-                    if (this->_responses[fd].getResInfo() != ResInfo::SENDING)
+                    if (this->_responses[fd].getSendProgress() != SendProgress::SENDING)
                         this->makeResponseMessage(fd);
                     this->sendResponse(fd);
                     if (this->_responses[fd].getReceiveProgress() == ReceiveProgress::ON_GOING)
@@ -1920,7 +1920,7 @@ bool
 Server::isResponseAllSended(int fd) const
 {
     return (this->_responses[fd].getParseProgress() == ParseProgress::FINISH &&
-            this->_responses[fd].getResInfo() == ResInfo::ALL_SENDED);
+            this->_responses[fd].getSendProgress() == SendProgress::ALL_SENDED);
 }
 
 void

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -726,13 +726,12 @@ Server::receiveRequest(int client_fd)
     Log::trace("< receiveRequest", 1);
 }
 
-std::string
+void
 Server::makeResponseMessage(int client_fd)
 {
     Log::trace("> makeResponseMessage", 1);
     timeval from;
     gettimeofday(&from, NULL);
-    
 
     Request& request = this->_requests[client_fd];
     Response& response = this->_responses[client_fd];
@@ -756,44 +755,42 @@ Server::makeResponseMessage(int client_fd)
     {
     case SendProgress::FINISH:
         if (method == "HEAD")
-            return ("");
+            response.setResponseMessage("");
 
         Log::printTimeDiff(from, 1);
         Log::trace("< makeResponseMessage", 1);
-        return (response.getTransmittingBody());
+        response.setResponseMessage(response.getTransmittingBody());
         break;
     case SendProgress::DEFAULT:
         response.setSendProgress(SendProgress::FINISH);
         if (method == "HEAD" || ((method == "PUT" || method == "DELETE") && response.getStatusCode().front() == '2'))
-            return (status_line + headers);
+            response.setResponseMessage(status_line + headers);
 
         Log::printTimeDiff(from, 1);
         Log::trace("< makeResponseMessage", 1);
-        return (status_line + headers + response.getTransmittingBody());
+        response.setResponseMessage(status_line + headers + response.getTransmittingBody());
         break;
     case SendProgress::CHUNK_START:
         if (request.getMethod() == "HEAD")
-            return (status_line + headers);
+            response.setResponseMessage(status_line + headers);
             
         Log::printTimeDiff(from, 1);
         Log::trace("< makeResponseMessage", 1);
-        return (status_line + headers + response.getTransmittingBody());
+        response.setResponseMessage(status_line + headers + response.getTransmittingBody());
         break;
     case SendProgress::CHUNK_PROGRESS:
         if (request.getMethod() == "HEAD")
-            return ("");
+            response.setResponseMessage("");
 
         Log::printTimeDiff(from, 1);
         Log::trace("< makeResponseMessage", 1);
-        return (response.getTransmittingBody());
+        response.setResponseMessage(response.getTransmittingBody());
         break;
     default:
-
         Log::printTimeDiff(from, 1);
         Log::trace("< makeResponseMessage", 1);
         break;
     }
-    return (status_line + headers + response.getTransmittingBody());
 }
 
 long long sended_bytes;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1246,7 +1246,8 @@ Server::run(int fd)
                     this->sendDataToCGI(fd);
                 else if (this->isClientSocket(fd))
                 {
-                    this->makeResponseMessage(fd);
+                    if (this->_responses[fd].getResInfo() != ResInfo::SENDING)
+                        this->makeResponseMessage(fd);
                     this->sendResponse(fd);
                     if (this->_responses[fd].getReceiveProgress() == ReceiveProgress::ON_GOING)
                     {
@@ -1967,7 +1968,8 @@ Server::makeCGIArgv(int client_fd)
 bool
 Server::isResponseAllSended(int fd) const
 {
-    return (this->_responses[fd].getSendProgress() == SendProgress::FINISH);
+    return (this->_responses[fd].getSendProgress() == SendProgress::FINISH &&
+            this->_responses[fd].getResInfo() == ResInfo::ALL_SENDED);
 }
 
 void

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -810,13 +810,11 @@ Server::sendResponse(int client_fd)
     int response_message_size = response_message.length();
     int remained = response_message_size - sended_response_size;
 
-    std::cout<<"\033[1;36m"<<response_message<<"\033[0m"<<std::endl;
     bytes = write(client_fd, &response_message.c_str()[sended_response_size], remained);
     if (bytes > 0)
     {
         sended_bytes += bytes;
         // std::cout<<response_message<<std::endl;
-        std::cout<<"\033[1;44;37m"<<"bytes: "<<bytes<<"\033[0m"<<std::endl;
         std::cout<<"\033[1;44;37m"<<"sended_bytes: "<<sended_bytes<<"\033[0m"<<std::endl;
         std::cout<<"\033[1;44;37m"<<"SendProgress: "<<Log::sendProgressToString(this->_responses[client_fd].getSendProgress())<<"\033[0m"<<std::endl;
 
@@ -832,18 +830,9 @@ Server::sendResponse(int client_fd)
             response.setResInfo(ResInfo::SENDING);
     }
     else if (bytes == 0)
-    {
-        // std::cout<<"\033[1;44;37m"<<"Debug 1"<<"\033[0m"<<std::endl;
-        // std::cout<<"\033[1;44;37m"<<"SendProgress: "<<(int)this->_responses[client_fd].getSendProgress()<<"\033[0m"<<std::endl;
-        // std::cout<<response_message<<std::endl;
-        // this->_responses[client_fd].setSendProgress(SendProgress::FINISH);
         throw (CannotWriteToClientException());
-    }
     else
-    {
-        // std::cout<<"\033[1;44;37m"<<"Debug 2"<<"\033[0m"<<std::endl;
         throw (CannotWriteToClientException());
-    }
 
     Log::printTimeDiff(from, 1);
     Log::trace("< sendResponse", 1);


### PR DESCRIPTION
# Refactor/ReadAndWrite

## 이번 PR에서 가장 큰 변화사항은 세 가지입니다.

1. sendResponse 함수에서 client에게 보낸 bytes수를 계산하여, 보내야 할 데이터 크기와 같을때까지 계속 write하는 것을 보장.
2. sendDataToCGI 함수에서의 usleep 제거
3. ReqInfo::MUST_CLEAR 분기 제거

---

### 1. sendResponse & makeResponseMessage

기존에는 makeResponseMessage 함수에서 response_message를 만들고, 그것을 클라이언트에게 전송했습니다.

하지만 만약 한 번에 write가 되지 않았을 때에 문제가 발생할 여지가 있었습니다.

그러할 경우 새롭게 response_message를 만들고, 새롭게 만들어진 response_message를 전송하는 등으로 클라이언트가 온전한 데이터를 받을 수 있음을 보장할 수 없었습니다.

따라서 ResInfo 라는 Enum을 만들었고, (ResInfo는 SendProgress로 변경했고, 기존 SendProgress는 ParseProgress로 명칭 변경했습니다.)
1. DEFAULT
2. SENDING
3. ALL_SENDED

세 가지 분기로 나누어서 SENDING이 아닐 때에만 makeResponseMessage 함수를 호출하게끔 변경하였습니다.

이후에 sendResponse 함수에서는 기존에 다른 곳에 write 할 때와 마찬가지로 remained를 계산하여 온전한 response_message의 length만큼 write가 가능하게끔 변경하였습니다.

---

### 2. sendDataToCGI 에서의 usleep 제거

[Select와 usleep (feat. Pipe의 I/O Stream)](https://github.com/get-Pork-Belly/Webserv/wiki/Select%EC%99%80-usleep-(feat.-Pipe%EC%9D%98-I-O-Stream))

위 위키에 상세하게 설명해 놓았습니다.

가장 큰 이슈는 write_fd_to_cgi 가 select에 걸리지 않았다는 것이었고, 때문에 read_fd_from_cgi 에 저장되어있는 스트림이 비워지지 않았는데 write를 하게 되어 문제가 생기는 것이었습니다.

따라서 write_fd_to_cgi를 select로 감지하게 변경하였고, 감지하는 동안에는 다른 fd들의 활동을 막아놓았기 때문에, usleep 없이 정상작동할 수 있게 되었습니다.

---

### 3. MUST_CLEAR

기존 MUST_CLEAR 분기에 존재했던 clearRequestBuffer 함수에서의 가장 큰 문제점은 select로 감지하며 버퍼가 다 비워지게끔 recv를 할 때, 전체 들어온 request의 양만큼 버퍼를 비웠는지 보장할 수 없었다는 것이었습니다.

이를 해결하기 위해 close를 한 이후에 버퍼가 비워져있는 지를 확인해보았고, close한 이후 같은 fd에 클라이언트를 connect 한 후 MSG_PEEK으로 해당 버퍼에 남아있는 값을 출력해 본 결과, close 이후에는 정상적으로 버퍼가 비워짐을 확인할 수 있었습니다.

따라서 MUST_CLEAR 분기는 없어도 될 것으로 파악하여 전부 제거해 주었습니다.

대신, body가 필요없는 method일 경우에 updateReqInfo 함수에서 바로 RequestFormatException throw를 던지게 변경하였고, RequestFormatException 예외처리 부분에서는 바로 client의 write셋을 올려주었습니다.

이후 writeSequence에서 응답을 정상적으로 모두 보낸 이후 status_code가 '2'로 시작하지 않는다면, 클라이언트와의 교신을 끊어주도록 처리하였습니다.

기존에 있었던 문제, GET일 때 body의 크기가 65536이었을 때는 완벽하게 처리가 되었고,

DELETE 메서드로 추가 확인 하였습니다.
- body가 있을 때 파일 삭제되지 않고 400 bad request 응답을 받음.
- body가 없을 때는 정상적으로 파일이 삭제됨.

---

이상입니다.