### PR TITLE
Fix/parse chunk data

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -526,146 +526,31 @@ Request::parseTargetChunkSize(const std::string& chunk_size_line)
 void
 Request::parseChunkData(char* buf, size_t bytes)
 {
-    // size_t index;
-    if (bytes <= CRLF_SIZE)
+    // \r
+    // \n
+    // C
+    // \r\n
+    // C\r
+    // C\r\n
+    // CC\r
+    // CCC
+    if (this->isCarriegeReturnTrimmed())
     {
-        if (bytes == CRLF_SIZE && buf[0] == '\r' && buf[1] == '\n')
-        {
-            // if (this->isCarriegeReturnTrimmed())
-            // {
-            //     this->appendBody("\r", 1);
-            //     this->setCarriegeReturnTrimmed(false);
-            // }
+        this->setCarriegeReturnTrimmed(false);
+        if (bytes == 1 && buf[0] == '\n')
             return ;
-        }
-        else if (bytes == 1 && buf[0] == '\n' && this->isCarriegeReturnTrimmed())
-        {
-            this->setCarriegeReturnTrimmed(false);
-            return ;
-        }
-        else if (bytes == 1 && buf[0] == '\r')
-        {
-            if (this->isCarriegeReturnTrimmed())
-            {
-                // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
-                // {
-                //     std::cout << "\033[31m\033[01m";
-                //     std::cout << "===============================================" << std::endl;
-                //     std::cout << "Debug -1" << std::endl;
-                //     std::cout << "bytes: " << bytes << std::endl;
-                //     std::cout << "index: " << index << std::endl;
-                //     std::cout << "===============================================" << std::endl;
-                //     std::cout << "\033[0m";
-                //     sleep(10);
-                // }
-                this->appendBody("\r", 1);
-            }
-            this->setCarriegeReturnTrimmed(true);
-            return ;
-        }
-        else if (bytes == 2 && buf[1] == '\r')
-        {
-            if (this->isCarriegeReturnTrimmed())
-            {
-                // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
-                // {
-                //     std::cout << "\033[31m\033[01m";
-                //     std::cout << "===============================================" << std::endl;
-                //     std::cout << "Debug 0" << std::endl;
-                //     std::cout << "bytes: " << bytes << std::endl;
-                //     std::cout << "index: " << index << std::endl;
-                //     std::cout << "===============================================" << std::endl;
-                //     std::cout << "\033[0m";
-                //     sleep(10);
-                // }
-                this->appendBody("\r", 1);
-                this->appendBody(buf, bytes - 1);
-                this->setCarriegeReturnTrimmed(true);
-            }
-            else
-            {
-                this->appendBody(buf, bytes - 1);
-                this->setCarriegeReturnTrimmed(true);
-            }
-            return ;
-        }
-        else
-        {
-            // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
-            // {
-            //     std::cout << "\033[31m\033[01m";
-            //     std::cout << "===============================================" << std::endl;
-            //     std::cout << "Debug 1" << std::endl;
-            //     std::cout << "bytes: " << bytes << std::endl;
-            //     std::cout << "index: " << index << std::endl;
-            //     std::cout << "===============================================" << std::endl;
-            //     std::cout << "\033[0m";
-            //     sleep(10);
-            // }
-            this->appendBody(buf, bytes);
-        }
-        return ;
+        this->appendBody("\r", 1);
     }
-    // if (this->isCarriegeReturnTrimmed())
-    // {
-    //     this->appendBody("\r", 1);
-    //     this->setCarriegeReturnTrimmed(false);
-    // }
-    // if (bytes == RECEIVE_SOCKET_STREAM_SIZE && buf[bytes - 2] == '\r' && buf[bytes - 1] == '\n')
-    //     this->appendBody(buf, bytes - 2);
-    // else if (bytes == RECEIVE_SOCKET_STREAM_SIZE && buf[bytes - 1] == '\r')
-    // {
-    //     this->setCarriegeReturnTrimmed(true);
-    //     this->appendBody(buf, bytes - 1);
-    // }
-    // else if (bytes == RECEIVE_SOCKET_STREAM_SIZE)
-    //     this->appendBody(buf, bytes);
-    if (buf[bytes - 1] == '\n' && buf[bytes - 2] == '\r')
+
+    if (buf[bytes - 1] == '\r')
     {
-        // if ((index = std::string(buf, bytes - CRLF_SIZE).find("\r")) != std::string::npos)
-        // {
-        //     std::cout << "\033[31m\033[01m";
-        //     std::cout << "===============================================" << std::endl;
-        //     std::cout << "Debug 2" << std::endl;
-        //     std::cout << "bytes: " << bytes << std::endl;
-        //     std::cout << "index: "  << index<< std::endl;
-        //     std::cout << "===============================================" << std::endl;
-        //     std::cout << "\033[0m";
-        //     sleep(10);
-        // }
-        this->appendBody(buf, bytes - CRLF_SIZE);
-    }
-    else if (buf[bytes - 1] == '\r')
-    {
-        // if ((index = std::string(buf, bytes - 1).find("\r")) != std::string::npos)
-        // {
-        //     std::cout << "\033[31m\033[01m";
-        //     std::cout << "===============================================" << std::endl;
-        //     std::cout << "Debug 3" << std::endl;
-        //     std::cout << "bytes: " << bytes << std::endl;
-        //     std::cout << "index: " << index << std::endl;
-        //     std::cout << "===============================================" << std::endl;
-        //     std::cout << "\033[0m";
-        //     sleep(10);
-        // }
         this->setCarriegeReturnTrimmed(true);
         this->appendBody(buf, bytes - 1);
     }
+    else if (bytes >= 2 && buf[bytes - 2] == '\r' && buf[bytes - 1] == '\n')
+        this->appendBody(buf, bytes - CRLF_SIZE);
     else
-    {
-        // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
-        // {
-        //     std::cout << "\033[31m\033[01m";
-        //     std::cout << "===============================================" << std::endl;
-        //     std::cout << "Debug 4" << std::endl;
-        //     std::cout << "bytes: " << bytes << std::endl;
-        //     std::cout << "index: " << index << std::endl;
-        //     std::cout << "===============================================" << std::endl;
-        //     std::cout << "\033[0m";
-        //     sleep(10);
-        // }
         this->appendBody(buf, bytes);
-    }
 }
 
 int

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -524,43 +524,148 @@ Request::parseTargetChunkSize(const std::string& chunk_size_line)
 }
 
 void
-Request::parseChunkDataAndSetChunkSize(char* buf, size_t bytes, int next_target_chunk_size)
-{
-    if (bytes == RECEIVE_SOCKET_STREAM_SIZE)
-        this->appendBody(buf, bytes);
-    else
-        this->appendBody(buf, bytes - 2);
-    this->setTargetChunkSize(next_target_chunk_size);
-}
-
-void
 Request::parseChunkData(char* buf, size_t bytes)
 {
+    size_t index;
     if (bytes <= CRLF_SIZE)
     {
-        if (!(bytes == 1 && buf[0] == '\n') && this->isCarriegeReturnTrimmed())
+        if (bytes == CRLF_SIZE && buf[0] == '\r' && buf[1] == '\n')
         {
-            this->appendBody("\r", 1);
+            // if (this->isCarriegeReturnTrimmed())
+            // {
+            //     this->appendBody("\r", 1);
+            //     this->setCarriegeReturnTrimmed(false);
+            // }
+            return ;
+        }
+        else if (bytes == 1 && buf[0] == '\n' && this->isCarriegeReturnTrimmed())
+        {
             this->setCarriegeReturnTrimmed(false);
+            return ;
+        }
+        else if (bytes == 1 && buf[0] == '\r')
+        {
+            if (this->isCarriegeReturnTrimmed())
+            {
+                // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
+                // {
+                //     std::cout << "\033[31m\033[01m";
+                //     std::cout << "===============================================" << std::endl;
+                //     std::cout << "Debug -1" << std::endl;
+                //     std::cout << "bytes: " << bytes << std::endl;
+                //     std::cout << "index: " << index << std::endl;
+                //     std::cout << "===============================================" << std::endl;
+                //     std::cout << "\033[0m";
+                //     sleep(10);
+                // }
+                this->appendBody("\r", 1);
+            }
+            this->setCarriegeReturnTrimmed(true);
+            return ;
+        }
+        else if (bytes == 2 && buf[1] == '\r')
+        {
+            if (this->isCarriegeReturnTrimmed())
+            {
+                // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
+                // {
+                //     std::cout << "\033[31m\033[01m";
+                //     std::cout << "===============================================" << std::endl;
+                //     std::cout << "Debug 0" << std::endl;
+                //     std::cout << "bytes: " << bytes << std::endl;
+                //     std::cout << "index: " << index << std::endl;
+                //     std::cout << "===============================================" << std::endl;
+                //     std::cout << "\033[0m";
+                //     sleep(10);
+                // }
+                this->appendBody("\r", 1);
+                this->appendBody(buf, bytes - 1);
+                this->setCarriegeReturnTrimmed(true);
+            }
+            else
+            {
+                this->appendBody(buf, bytes - 1);
+                this->setCarriegeReturnTrimmed(true);
+            }
+            return ;
+        }
+        else
+        {
+            // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
+            // {
+            //     std::cout << "\033[31m\033[01m";
+            //     std::cout << "===============================================" << std::endl;
+            //     std::cout << "Debug 1" << std::endl;
+            //     std::cout << "bytes: " << bytes << std::endl;
+            //     std::cout << "index: " << index << std::endl;
+            //     std::cout << "===============================================" << std::endl;
+            //     std::cout << "\033[0m";
+            //     sleep(10);
+            // }
+            this->appendBody(buf, bytes);
         }
         return ;
     }
-    if (this->isCarriegeReturnTrimmed())
+    // if (this->isCarriegeReturnTrimmed())
+    // {
+    //     this->appendBody("\r", 1);
+    //     this->setCarriegeReturnTrimmed(false);
+    // }
+    // if (bytes == RECEIVE_SOCKET_STREAM_SIZE && buf[bytes - 2] == '\r' && buf[bytes - 1] == '\n')
+    //     this->appendBody(buf, bytes - 2);
+    // else if (bytes == RECEIVE_SOCKET_STREAM_SIZE && buf[bytes - 1] == '\r')
+    // {
+    //     this->setCarriegeReturnTrimmed(true);
+    //     this->appendBody(buf, bytes - 1);
+    // }
+    // else if (bytes == RECEIVE_SOCKET_STREAM_SIZE)
+    //     this->appendBody(buf, bytes);
+    if (buf[bytes - 1] == '\n' && buf[bytes - 2] == '\r')
     {
-        this->appendBody("\r", 1);
-        this->setCarriegeReturnTrimmed(false);
+        // if ((index = std::string(buf, bytes - CRLF_SIZE).find("\r")) != std::string::npos)
+        // {
+        //     std::cout << "\033[31m\033[01m";
+        //     std::cout << "===============================================" << std::endl;
+        //     std::cout << "Debug 2" << std::endl;
+        //     std::cout << "bytes: " << bytes << std::endl;
+        //     std::cout << "index: "  << index<< std::endl;
+        //     std::cout << "===============================================" << std::endl;
+        //     std::cout << "\033[0m";
+        //     sleep(10);
+        // }
+        this->appendBody(buf, bytes - CRLF_SIZE);
     }
-    if (bytes == RECEIVE_SOCKET_STREAM_SIZE && buf[bytes - 2] == '\r' && buf[bytes - 1] == '\n')
-        this->appendBody(buf, bytes - 2);
-    else if (bytes == RECEIVE_SOCKET_STREAM_SIZE && buf[bytes - 1] == '\r')
+    else if (buf[bytes - 1] == '\r')
     {
+        // if ((index = std::string(buf, bytes - 1).find("\r")) != std::string::npos)
+        // {
+        //     std::cout << "\033[31m\033[01m";
+        //     std::cout << "===============================================" << std::endl;
+        //     std::cout << "Debug 3" << std::endl;
+        //     std::cout << "bytes: " << bytes << std::endl;
+        //     std::cout << "index: " << index << std::endl;
+        //     std::cout << "===============================================" << std::endl;
+        //     std::cout << "\033[0m";
+        //     sleep(10);
+        // }
         this->setCarriegeReturnTrimmed(true);
         this->appendBody(buf, bytes - 1);
     }
-    else if (bytes == RECEIVE_SOCKET_STREAM_SIZE)
-        this->appendBody(buf, bytes);
     else
-        this->appendBody(buf, bytes - CRLF_SIZE);
+    {
+        // if ((index = std::string(buf, bytes).find("\r")) != std::string::npos)
+        // {
+        //     std::cout << "\033[31m\033[01m";
+        //     std::cout << "===============================================" << std::endl;
+        //     std::cout << "Debug 4" << std::endl;
+        //     std::cout << "bytes: " << bytes << std::endl;
+        //     std::cout << "index: " << index << std::endl;
+        //     std::cout << "===============================================" << std::endl;
+        //     std::cout << "\033[0m";
+        //     sleep(10);
+        // }
+        this->appendBody(buf, bytes);
+    }
 }
 
 int

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -526,7 +526,7 @@ Request::parseTargetChunkSize(const std::string& chunk_size_line)
 void
 Request::parseChunkData(char* buf, size_t bytes)
 {
-    size_t index;
+    // size_t index;
     if (bytes <= CRLF_SIZE)
     {
         if (bytes == CRLF_SIZE && buf[0] == '\r' && buf[1] == '\n')


### PR DESCRIPTION
### 문제)
테스터를 통해 POST 1억 byte 바디 요청을 보내는 도중 postman 등으로 연달아 post 요청을 보내면 `bad cgi size returned`가 출력된다.

### 원인)
recv target_size보다 큰 데이터가 client_socket buffer에 있음에도 target_size 보다 적은 bytes 만큼 recv되는 경우가 있고, 이 경우 chunk data parse가 적절히 진행되지 않는 경우가 발생했기 때문입니다.
예를 들어 버퍼로부터 `Lolem\r` 까지만 읽히고 `'\r\n'`가 연이어 읽히는 경우, body에 `Lolem\r`까지 저장되어야하지만 `Lolem`까지만 파싱되어 body에 포함되었어야할 `\r`이 유실되는 경우가 발생해왔습니다.

### 해결)
parseChunkData의 분기를 수정하여 해결했습니다.