### PR TITLE
REFACTOR: printFdCopy/OriginSets with width

### DIFF
--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -44,8 +44,8 @@ public:
     static void printLocationConfig(const std::map<std::string, location_info>& loc_config);
     static void printLocationInfo(const location_info& loc_info);
 
-    static void printFdCopySets(ServerManager& server_manager);
-    static void printFdSets(ServerManager& server_manager);
+    static void printFdCopySets(ServerManager& server_manager, int width);
+    static void printFdSets(ServerManager& server_manager, int width);
     static void printTimeSec(timeval& tv);
 };
 

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -342,41 +342,127 @@ Log::printLocationInfo(const location_info& loc_info)
 }
 
 void
-Log::printFdCopySets(ServerManager& server_manager)
+Log::printFdCopySets(ServerManager& server_manager, int width)
 {
+    int max_fd = server_manager.getFdMax() + 1;
+    bool is_set;
+
     std::cout<<"READ FD COPY SET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsCopySet(i, FdSet::READ)<<" |";
-    std::cout<<std::endl;
+    int start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsCopySet(i, FdSet::READ);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
 
     std::cout<<"WRITE FD COPY SET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsCopySet(i, FdSet::WRITE)<<" |";
-    std::cout<<std::endl;
+    start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsCopySet(i, FdSet::WRITE);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
 }
 
 void
-Log::printFdSets(ServerManager& server_manager)
+Log::printFdSets(ServerManager& server_manager, int width)
 {
-    std::cout<<"READ ORIGIN FDSET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsOriginSet(i, FdSet::READ)<<" |";
-    std::cout<<std::endl;
+    int max_fd = server_manager.getFdMax() + 1;
+    bool is_set;
 
-    std::cout<<"WRITE ORIGIN FDSET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsOriginSet(i, FdSet::WRITE)<<" |";
-    std::cout<<std::endl;
+    std::cout<<"READ FD ORIGIN SET"<<std::endl;
+    int start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsOriginSet(i, FdSet::READ);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
+
+    std::cout<<"WRITE FD ORIGIN SET"<<std::endl;
+    start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsOriginSet(i, FdSet::WRITE);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -284,9 +284,9 @@ ServerManager::runServers()
         this->_copy_writefds = this->_writefds;
         this->_copy_exceptfds = this->_exceptfds;
 
-        // std::cout<<"\033[1;44;37m"<<"Before select!"<<"\033[0m"<<std::endl;
-        // Log::printFdCopySets(*this);
-        // Log::printFdSets(*this);
+        std::cout<<"\033[1;44;37m"<<"Before select!"<<"\033[0m"<<std::endl;
+        Log::printFdCopySets(*this, 10);
+        Log::printFdSets(*this, 10);
         if ((selected_fds = select(this->getFdMax() + 1, &this->_copy_readfds, 
             &this->_copy_writefds, &this->_copy_exceptfds, &timeout)) == -1)
         {
@@ -301,8 +301,8 @@ ServerManager::runServers()
         else
         {
         // std::cout<<"\033[1;44;37m"<<"After select!"<<"\033[0m"<<std::endl;
-        // Log::printFdCopySets(*this);
-        // Log::printFdSets(*this);
+        // Log::printFdCopySets(*this, 10);
+        // Log::printFdSets(*this, 10);
             for (int fd = 0; fd < this->getFdMax() + 1; fd++)
             {
                 if (this->fdIsCopySet(fd, FdSet::ALL))


### PR DESCRIPTION
AS-IS:
	Just print fdsets.

TO-BE:
	Not only print fd set but set printing width formatting by setw().

fd를 프린트하는 로그함수가 너무 불편하여 수정하였습니다. 

1. 두번째 인자로 출력하고자 하는 가로 길이를 지정할 수 있습니다. 터미널 크기에 맞춰서 지정하세요!
2. fdset에서 isSet 값이 True인 경우 붉게 하이라이팅됩니다. 