### PR TITLE
REFACTOR: printFdCopy/OriginSets with width

### DIFF
--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -44,8 +44,8 @@ public:
     static void printLocationConfig(const std::map<std::string, location_info>& loc_config);
     static void printLocationInfo(const location_info& loc_info);
 
-    static void printFdCopySets(ServerManager& server_manager);
-    static void printFdSets(ServerManager& server_manager);
+    static void printFdCopySets(ServerManager& server_manager, int width);
+    static void printFdSets(ServerManager& server_manager, int width);
     static void printTimeSec(timeval& tv);
 };
 

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -342,41 +342,127 @@ Log::printLocationInfo(const location_info& loc_info)
 }
 
 void
-Log::printFdCopySets(ServerManager& server_manager)
+Log::printFdCopySets(ServerManager& server_manager, int width)
 {
+    int max_fd = server_manager.getFdMax() + 1;
+    bool is_set;
+
     std::cout<<"READ FD COPY SET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsCopySet(i, FdSet::READ)<<" |";
-    std::cout<<std::endl;
+    int start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsCopySet(i, FdSet::READ);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
 
     std::cout<<"WRITE FD COPY SET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsCopySet(i, FdSet::WRITE)<<" |";
-    std::cout<<std::endl;
+    start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsCopySet(i, FdSet::WRITE);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
 }
 
 void
-Log::printFdSets(ServerManager& server_manager)
+Log::printFdSets(ServerManager& server_manager, int width)
 {
-    std::cout<<"READ ORIGIN FDSET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsOriginSet(i, FdSet::READ)<<" |";
-    std::cout<<std::endl;
+    int max_fd = server_manager.getFdMax() + 1;
+    bool is_set;
 
-    std::cout<<"WRITE ORIGIN FDSET"<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<i<<" |";
-    std::cout<<std::endl;
-    for (int i = 0; i < server_manager.getFdMax() + 1; i++)
-        std::cout<<"| "<<server_manager.fdIsOriginSet(i, FdSet::WRITE)<<" |";
-    std::cout<<std::endl;
+    std::cout<<"READ FD ORIGIN SET"<<std::endl;
+    int start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsOriginSet(i, FdSet::READ);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
+
+    std::cout<<"WRITE FD ORIGIN SET"<<std::endl;
+    start_idx = 0;
+    while(start_idx < max_fd)
+    {
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        std::cout<<"|"<<std::endl;
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+            std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
+        std::cout<<"|"<<std::endl;
+
+        for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
+        {
+            is_set = server_manager.fdIsOriginSet(i, FdSet::WRITE);
+
+            if (is_set)
+            {
+                std::cout<<"| ";
+                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<" ";
+            }
+            else
+                std::cout<<"| "<<std::setw(6)<<is_set<<" ";
+        }
+        std::cout<<"|"<<std::endl;
+        start_idx += width;
+    }
 }

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -374,9 +374,6 @@ Log::printFdCopySets(ServerManager& server_manager, int width)
                 std::cout<<"| ";
                 std::cout<<color<<std::setw(6)<<is_set<<"\033[0m";
                 std::cout<<" ";
-                // std::cout<<"| ";
-                // std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
-                // std::cout<<" ";
             }
             else
                 std::cout<<"| "<<std::setw(6)<<is_set<<" ";
@@ -412,9 +409,6 @@ Log::printFdCopySets(ServerManager& server_manager, int width)
                 std::cout<<"| ";
                 std::cout<<color<<std::setw(6)<<is_set<<"\033[0m";
                 std::cout<<" ";
-                // std::cout<<"| ";
-                // std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
-                // std::cout<<" ";
             }
             else
                 std::cout<<"| "<<std::setw(6)<<is_set<<" ";
@@ -459,9 +453,6 @@ Log::printFdSets(ServerManager& server_manager, int width)
                 std::cout<<"| ";
                 std::cout<<color<<std::setw(6)<<is_set<<"\033[0m";
                 std::cout<<" ";
-                // std::cout<<"| ";
-                // std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
-                // std::cout<<" ";
             }
             else
                 std::cout<<"| "<<std::setw(6)<<is_set<<" ";
@@ -488,7 +479,6 @@ Log::printFdSets(ServerManager& server_manager, int width)
         {
             is_set = server_manager.fdIsOriginSet(i, FdSet::WRITE);
             std::string color;
-            // std::string purple = "\033[41;35m";
             if (is_set)
             {
                 if (server_manager.getFdType(i) == FdType::CLOSED)

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -352,7 +352,10 @@ Log::printFdCopySets(ServerManager& server_manager, int width)
     while(start_idx < max_fd)
     {
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
-            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+            if (server_manager.getFdType(i) == FdType::RESOURCE)
+                std::cout<<std::right<<"|"<<std::setw(7)<< " STATIC ";
+            else
+                std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
         std::cout<<"|"<<std::endl;
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
             std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
@@ -361,12 +364,19 @@ Log::printFdCopySets(ServerManager& server_manager, int width)
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
         {
             is_set = server_manager.fdIsCopySet(i, FdSet::READ);
-
+            std::string color;
             if (is_set)
             {
+                if (server_manager.getFdType(i) == FdType::CLOSED)
+                    color = "\033[46;1;97m";
+                else
+                    color = "\033[41;1;97m";
                 std::cout<<"| ";
-                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<color<<std::setw(6)<<is_set<<"\033[0m";
                 std::cout<<" ";
+                // std::cout<<"| ";
+                // std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                // std::cout<<" ";
             }
             else
                 std::cout<<"| "<<std::setw(6)<<is_set<<" ";
@@ -380,7 +390,10 @@ Log::printFdCopySets(ServerManager& server_manager, int width)
     while(start_idx < max_fd)
     {
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
-            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+            if (server_manager.getFdType(i) == FdType::RESOURCE)
+                std::cout<<std::right<<"|"<<std::setw(7)<< " STATIC ";
+            else
+                std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
         std::cout<<"|"<<std::endl;
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
             std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
@@ -389,12 +402,19 @@ Log::printFdCopySets(ServerManager& server_manager, int width)
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
         {
             is_set = server_manager.fdIsCopySet(i, FdSet::WRITE);
-
+            std::string color;
             if (is_set)
             {
+                if (server_manager.getFdType(i) == FdType::CLOSED)
+                    color = "\033[46;1;97m";
+                else
+                    color = "\033[41;1;97m";
                 std::cout<<"| ";
-                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<color<<std::setw(6)<<is_set<<"\033[0m";
                 std::cout<<" ";
+                // std::cout<<"| ";
+                // std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                // std::cout<<" ";
             }
             else
                 std::cout<<"| "<<std::setw(6)<<is_set<<" ";
@@ -415,7 +435,12 @@ Log::printFdSets(ServerManager& server_manager, int width)
     while(start_idx < max_fd)
     {
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
-            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        {
+            if (server_manager.getFdType(i) == FdType::RESOURCE)
+                std::cout<<std::right<<"|"<<std::setw(7)<< " STATIC ";
+            else
+                std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+        }
         std::cout<<"|"<<std::endl;
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
             std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
@@ -424,12 +449,19 @@ Log::printFdSets(ServerManager& server_manager, int width)
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
         {
             is_set = server_manager.fdIsOriginSet(i, FdSet::READ);
-
+            std::string color;
             if (is_set)
             {
+                if (server_manager.getFdType(i) == FdType::CLOSED)
+                    color = "\033[46;1;97m";
+                else
+                    color = "\033[41;1;97m";
                 std::cout<<"| ";
-                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<color<<std::setw(6)<<is_set<<"\033[0m";
                 std::cout<<" ";
+                // std::cout<<"| ";
+                // std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                // std::cout<<" ";
             }
             else
                 std::cout<<"| "<<std::setw(6)<<is_set<<" ";
@@ -443,7 +475,10 @@ Log::printFdSets(ServerManager& server_manager, int width)
     while(start_idx < max_fd)
     {
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
-            std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
+            if (server_manager.getFdType(i) == FdType::RESOURCE)
+                std::cout<<std::right<<"|"<<std::setw(7)<< " STATIC ";
+            else
+                std::cout<<std::right<<"|"<<std::setw(7)<<Log::fdTypeToString(server_manager.getFdType(i))<<" ";
         std::cout<<"|"<<std::endl;
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
             std::cout<<"| fd "<<std::setw(3)<<std::right<<i<<" ";
@@ -452,11 +487,16 @@ Log::printFdSets(ServerManager& server_manager, int width)
         for (int i = start_idx; i < std::min(start_idx + width, max_fd); i++)
         {
             is_set = server_manager.fdIsOriginSet(i, FdSet::WRITE);
-
+            std::string color;
+            // std::string purple = "\033[41;35m";
             if (is_set)
             {
+                if (server_manager.getFdType(i) == FdType::CLOSED)
+                    color = "\033[46;1;97m";
+                else
+                    color = "\033[41;1;97m";
                 std::cout<<"| ";
-                std::cout<<"\033[41;1;97m"<<std::setw(6)<<is_set<<"\033[0m";
+                std::cout<<color<<std::setw(6)<<is_set<<"\033[0m";
                 std::cout<<" ";
             }
             else

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -284,9 +284,9 @@ ServerManager::runServers()
         this->_copy_writefds = this->_writefds;
         this->_copy_exceptfds = this->_exceptfds;
 
-        // std::cout<<"\033[1;44;37m"<<"Before select!"<<"\033[0m"<<std::endl;
-        // Log::printFdCopySets(*this);
-        // Log::printFdSets(*this);
+        std::cout<<"\033[1;44;37m"<<"Before select!"<<"\033[0m"<<std::endl;
+        Log::printFdCopySets(*this, 10);
+        Log::printFdSets(*this, 10);
         if ((selected_fds = select(this->getFdMax() + 1, &this->_copy_readfds, 
             &this->_copy_writefds, &this->_copy_exceptfds, &timeout)) == -1)
         {
@@ -301,8 +301,8 @@ ServerManager::runServers()
         else
         {
         // std::cout<<"\033[1;44;37m"<<"After select!"<<"\033[0m"<<std::endl;
-        // Log::printFdCopySets(*this);
-        // Log::printFdSets(*this);
+        // Log::printFdCopySets(*this, 10);
+        // Log::printFdSets(*this, 10);
             for (int fd = 0; fd < this->getFdMax() + 1; fd++)
             {
                 if (this->fdIsCopySet(fd, FdSet::ALL))


### PR DESCRIPTION
AS-IS:
	Just print fdsets.
TO-BE:
	Not only print fd set but set printing width formatting by setw().

1. 출력할 fd set의 line_width를 지정할 수 있습니다.
2. set된 fd라면 붉게 하이라이팅됩니다.

두번째 인자로 주어진 width가 7일 때 예시
![image](https://user-images.githubusercontent.com/54612343/100463944-03ec7d00-3110-11eb-820a-6d03c61e9ed8.png)

두번째 인자로 주어진 width가 5일 때 예시
![image](https://user-images.githubusercontent.com/54612343/100464068-3ac29300-3110-11eb-899c-ff75694a6e84.png)

