### PR TITLE
Fix/receive chunk size and receive last chunk

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -22,7 +22,6 @@ private:
     std::string _body;
     std::string _status_code;
     RecvRequest _info;
-    bool _is_buffer_left;
     std::string _ip_address;
     int _transfered_body_size;
     std::string _remote_user;
@@ -53,7 +52,6 @@ public:
     const std::string& getBody() const;
     const std::string& getStatusCode() const;
     const RecvRequest& getRecvRequest() const;
-    bool getIsBufferLeft() const;
     const std::string& getIpAddress() const;
     int getContentLength() const;
     int getTransferedBodySize() const;
@@ -76,7 +74,6 @@ public:
     void setBody(const std::string& body);
     void setStatusCode(const std::string& code);
     void setRecvRequest(const RecvRequest& info);
-    void setIsBufferLeft(const bool& is_left_buffer);
     void setIpAddress(const std::string& ip_address);
     void setTransferedBodySize(const int transfered_body_size);
     void setAuthType(const std::string& auth_type);
@@ -99,7 +96,6 @@ public:
     bool isBodyUnnecessary() const;
     bool isNormalBody() const;
     bool isChunkedBody() const;
-    bool isContentLeftInBuffer() const;
 
     int peekMessageFromClient(int client_fd, char* buf);
     void raiseRecvCounts();

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -29,6 +29,9 @@ private:
     std::string _auth_type;
     int _target_chunk_size;
     int _received_chunk_data_length;
+    int _index_of_crlf_in_chunk_size;
+    int _received_chunk_size_length;
+    std::string _chunk_size;
 
     int _recv_counts;
     bool _carriege_return_trimmed;
@@ -61,6 +64,9 @@ public:
     int getTargetChunkSize() const;
     int getReceivedChunkDataLength() const;
     bool getCarriegeReturnTrimmed() const;
+    int getIndexOfCRLFInChunkSize() const;
+    int getReceivedChunkSizeLength() const;
+    const std::string& getChunkSize() const;
 
     int getReceiveCounts() const;
     const std::string& getTempBuffer() const;
@@ -81,6 +87,9 @@ public:
     void setRemoteIdent(const std::string& remote_ident);
     void setTargetChunkSize(const int target_size);
     void setReceivedChunkDataLength(const int received_chunk_data_length);
+    void setIndexOfCRLFInChunkSize(const int index_of_crlf_in_chunk_size);
+    void setReceivedChunkSizeLength(const int received_chunk_size_length);
+    void setChunkSize(const std::string& chunk_size);
 
     void setReceiveCounts(const int recv_count);
     void setCarriegeReturnTrimmed(const bool trimmed);
@@ -122,6 +131,7 @@ public:
     void appendBody(char* buf, int bytes);
     void appendBody(const char* buf, int bytes);
     void appendTempBuffer(char* buf, int bytes);
+    void appendChunkSize(char* buf, int bytes);
 
     void parseTargetChunkSize(const std::string& chunk_size_line);
     void parseChunkDataAndSetChunkSize(char* buf, size_t bytes, int next_target_chunk_size);

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -28,7 +28,7 @@ private:
     std::string _remote_ident;
     std::string _auth_type;
     int _target_chunk_size;
-    int _received_chunk_data_size;
+    int _received_chunk_data_length;
 
     int _recv_counts;
     bool _carriege_return_trimmed;
@@ -59,7 +59,7 @@ public:
     const std::string& getRemoteUser() const;
     const std::string& getRemoteIdent() const;
     int getTargetChunkSize() const;
-    int getReceivedChunkDataSize() const;
+    int getReceivedChunkDataLength() const;
     bool getCarriegeReturnTrimmed() const;
 
     int getReceiveCounts() const;
@@ -80,7 +80,7 @@ public:
     void setRemoteUser(const std::string& remote_user);
     void setRemoteIdent(const std::string& remote_ident);
     void setTargetChunkSize(const int target_size);
-    void setReceivedChunkDataSize(const int received_chunk_data_size);
+    void setReceivedChunkDataLength(const int received_chunk_data_length);
 
     void setReceiveCounts(const int recv_count);
     void setCarriegeReturnTrimmed(const bool trimmed);

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -32,6 +32,8 @@ private:
     int _index_of_crlf_in_chunk_size;
     int _received_chunk_size_length;
     std::string _chunk_size;
+    int _received_last_chunk_data_length;
+    std::string _last_chunk_data;
 
     int _recv_counts;
     bool _carriege_return_trimmed;
@@ -67,6 +69,8 @@ public:
     int getIndexOfCRLFInChunkSize() const;
     int getReceivedChunkSizeLength() const;
     const std::string& getChunkSize() const;
+    int getReceivedLastChunkDataLength() const;
+    const std::string& getLastChunkData() const;
 
     int getReceiveCounts() const;
     const std::string& getTempBuffer() const;
@@ -90,6 +94,8 @@ public:
     void setIndexOfCRLFInChunkSize(const int index_of_crlf_in_chunk_size);
     void setReceivedChunkSizeLength(const int received_chunk_size_length);
     void setChunkSize(const std::string& chunk_size);
+    void setReceivedLastChunkDataLength(const int received_last_chunk_data_length);
+    void setLastChunkData(const std::string& last_chunk_data);
 
     void setReceiveCounts(const int recv_count);
     void setCarriegeReturnTrimmed(const bool trimmed);
@@ -132,6 +138,7 @@ public:
     void appendBody(const char* buf, int bytes);
     void appendTempBuffer(char* buf, int bytes);
     void appendChunkSize(char* buf, int bytes);
+    void appendLastChunkData(char* buf, int bytes);
 
     void parseTargetChunkSize(const std::string& chunk_size_line);
     void parseChunkDataAndSetChunkSize(char* buf, size_t bytes, int next_target_chunk_size);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -139,7 +139,7 @@ public:
     bool isCGIReadPipe(int fd) const;
     bool isCGIWritePipe(int fd) const;
 
-    void receiveChunkSize(int fd, size_t index_of_crlf);
+    void receiveChunkSize(int fd);
     void receiveChunkData(int client_fd, int receive_size);
     void receiveLastChunkData(int fd);
     bool isExistCRLFInChunkSize(int fd);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -24,6 +24,7 @@ const int RECEIVE_SOCKET_STREAM_SIZE = 65536;
 const int SEND_PIPE_STREAM_SIZE = 65536;
 const int CHUNKED_LINE_LENGTH = 65536;
 const int DEFAULT_TARGET_CHUNK_SIZE = -2;
+const int DEFAULT_INDEX_OF_CRLF = -1;
 const int CRLF_SIZE = 2;
 const int NUM_OF_META_VARIABLES = 18;
 const int DEFAULT_FD = -1;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -147,6 +147,7 @@ public:
     bool isLastSequenceOfParsingChunk(int fd);
     int calculateReceiveTargetSizeOfChunkData(int fd);
     bool isReceivedChunkDataToTheEnd(int fd);
+    void prepareReceiveNextChunkSize(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -145,6 +145,7 @@ public:
     bool isNotYetSetTargetChunkSize(int fd);
     void findCRLFInChunkSize(int fd, const std::string& buf);
     bool isLastSequenceOfParsingChunk(int fd);
+    int calculateReceiveTargetSizeOfChunkData(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -143,6 +143,7 @@ public:
     void receiveLastChunkData(int fd);
     bool isExistCRLFInChunkSize(int fd);
     bool isNotYetSetTargetChunkSize(int fd);
+    void findCRLFInChunkSize(int fd, const std::string& buf);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -146,6 +146,7 @@ public:
     void findCRLFInChunkSize(int fd, const std::string& buf);
     bool isLastSequenceOfParsingChunk(int fd);
     int calculateReceiveTargetSizeOfChunkData(int fd);
+    bool isReceivedChunkDataToTheEnd(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -148,8 +148,8 @@ public:
     bool isLastSequenceOfParsingChunk(int fd);
     int calculateReceiveTargetSizeOfChunkData(int fd);
     bool isReceivedChunkDataToTheEnd(int fd);
-    void prepareReceiveNextChunkSize(int fd);
-    void prepareReceiveNextChunkData(int fd);
+    void prepareToReceiveNextChunkSize(int fd);
+    void prepareToReceiveNextChunkData(int fd);
     void finishChunkSequence(int fd);
 
 public:

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -150,7 +150,7 @@ public:
     bool isReceivedChunkDataToTheEnd(int fd);
     void prepareReceiveNextChunkSize(int fd);
     void prepareReceiveNextChunkData(int fd);
-    void completeChunkSequence(int fd);
+    void finishChunkSequence(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -141,6 +141,7 @@ public:
     void receiveChunkSize(int fd, size_t index_of_crlf);
     void receiveChunkData(int client_fd, int receive_size);
     void receiveLastChunkData(int fd);
+    bool isExistCRLFInChunkSize(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -147,7 +147,7 @@ public:
     void findCRLFInChunkSize(int fd, const std::string& buf);
     bool isLastSequenceOfParsingChunk(int fd);
     int calculateReceiveTargetSizeOfChunkData(int fd);
-    bool isReceivedChunkDataToTheEnd(int fd);
+    bool isChunkDataAllReceived(int fd);
     void prepareToReceiveNextChunkSize(int fd);
     void prepareToReceiveNextChunkData(int fd);
     void finishChunkSequence(int fd);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -148,6 +148,8 @@ public:
     int calculateReceiveTargetSizeOfChunkData(int fd);
     bool isReceivedChunkDataToTheEnd(int fd);
     void prepareReceiveNextChunkSize(int fd);
+    void prepareReceiveNextChunkData(int fd);
+    void completeChunkSequence(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -144,6 +144,7 @@ public:
     bool isExistCRLFInChunkSize(int fd);
     bool isNotYetSetTargetChunkSize(int fd);
     void findCRLFInChunkSize(int fd, const std::string& buf);
+    bool isLastSequenceOfParsingChunk(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -142,6 +142,7 @@ public:
     void receiveChunkData(int client_fd, int receive_size);
     void receiveLastChunkData(int fd);
     bool isExistCRLFInChunkSize(int fd);
+    bool isNotYetSetTargetChunkSize(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -16,7 +16,8 @@ _protocol(""), _body(""), _status_code("200"),
 _info(RecvRequest::REQUEST_LINE), _ip_address(""),
 _transfered_body_size(0), _target_chunk_size(DEFAULT_TARGET_CHUNK_SIZE),
 _received_chunk_data_length(0), _index_of_crlf_in_chunk_size(-1),
-_received_chunk_size_length(0), _chunk_size(""), _recv_counts(0),
+_received_chunk_size_length(0), _chunk_size(""),
+_received_last_chunk_data_length(0), _last_chunk_data(""), _recv_counts(0),
 _carriege_return_trimmed(false), _temp_buffer("")
  {}
 
@@ -29,7 +30,8 @@ _ip_address(other._ip_address), _transfered_body_size(other._transfered_body_siz
 _target_chunk_size(other._target_chunk_size), _received_chunk_data_length(other._received_chunk_data_length),
 _index_of_crlf_in_chunk_size(other._index_of_crlf_in_chunk_size),
 _received_chunk_size_length(other._received_chunk_size_length),
-_chunk_size(other._chunk_size), _recv_counts(other._recv_counts),
+_chunk_size(other._chunk_size), _received_last_chunk_data_length(other._received_last_chunk_data_length),
+_last_chunk_data(other._last_chunk_data), _recv_counts(other._recv_counts),
 _carriege_return_trimmed(other._carriege_return_trimmed), _temp_buffer(other._temp_buffer)
 {}
 
@@ -51,6 +53,8 @@ Request::operator=(const Request& other)
     this->_index_of_crlf_in_chunk_size = other._index_of_crlf_in_chunk_size;
     this->_received_chunk_size_length = other._received_chunk_size_length;
     this->_chunk_size = other._chunk_size;
+    this->_received_last_chunk_data_length = other._received_last_chunk_data_length;
+    this->_last_chunk_data = other._last_chunk_data;
     this->_recv_counts = other._recv_counts;
     this->_carriege_return_trimmed = other._carriege_return_trimmed;
     this->_temp_buffer = other._temp_buffer;
@@ -193,6 +197,18 @@ Request::getTempBuffer() const
     return (this->_temp_buffer);
 }
 
+int
+Request::getReceivedLastChunkDataLength() const
+{
+    return (this->_received_last_chunk_data_length);
+}
+
+const std::string&
+Request::getLastChunkData() const
+{
+    return (this->_last_chunk_data);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -321,6 +337,18 @@ void
 Request::setTempBuffer(const std::string& temp_buffer)
 {
     this->_temp_buffer = temp_buffer;
+}
+
+void
+Request::setReceivedLastChunkDataLength(const int received_last_chunk_data_length)
+{
+    this->_received_last_chunk_data_length = received_last_chunk_data_length;
+}
+
+void
+Request::setLastChunkData(const std::string& last_chunk_data)
+{
+    this->_last_chunk_data = last_chunk_data;
 }
 
 /*============================================================================*/
@@ -642,6 +670,12 @@ Request::appendChunkSize(char* buf, int bytes)
 }
 
 void
+Request::appendLastChunkData(char* buf, int bytes)
+{
+    this->_last_chunk_data.append(buf, bytes);
+}
+
+void
 Request::init()
 {
     this->_method = "";
@@ -659,6 +693,8 @@ Request::init()
     this->_index_of_crlf_in_chunk_size = -1;
     this->_received_chunk_size_length = 0;
     this->_chunk_size = "";
+    this->_received_last_chunk_data_length = 0;
+    this->_last_chunk_data = "";
     this->_carriege_return_trimmed = false;
     this->_recv_counts = 0;
     this->_temp_buffer = "";

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -15,7 +15,7 @@ Request::Request()
 _protocol(""), _body(""), _status_code("200"),
 _info(RecvRequest::REQUEST_LINE), _ip_address(""),
 _transfered_body_size(0), _target_chunk_size(DEFAULT_TARGET_CHUNK_SIZE),
-_received_chunk_data_size(0), _recv_counts(0),
+_received_chunk_data_length(0), _recv_counts(0),
 _carriege_return_trimmed(false), _temp_buffer("")
  {}
 
@@ -26,7 +26,7 @@ _protocol(other._protocol), _body(other._body),
 _status_code(other._status_code), _info(other._info),
 _ip_address(other._ip_address), _transfered_body_size(other._transfered_body_size),
 _target_chunk_size(other._target_chunk_size),
-_received_chunk_data_size(other._received_chunk_data_size), _recv_counts(other._recv_counts),
+_received_chunk_data_length(other._received_chunk_data_length), _recv_counts(other._recv_counts),
 _carriege_return_trimmed(other._carriege_return_trimmed), _temp_buffer(other._temp_buffer)
 {}
 
@@ -44,7 +44,7 @@ Request::operator=(const Request& other)
     this->_ip_address = other._ip_address;
     this->_transfered_body_size = other._transfered_body_size;
     this->_target_chunk_size = other._target_chunk_size;
-    this->_received_chunk_data_size = other._received_chunk_data_size;
+    this->_received_chunk_data_length = other._received_chunk_data_length;
     this->_recv_counts = other._recv_counts;
     this->_carriege_return_trimmed = other._carriege_return_trimmed;
     this->_temp_buffer = other._temp_buffer;
@@ -146,9 +146,9 @@ Request::getTargetChunkSize() const
 }
 
 int
-Request::getReceivedChunkDataSize() const
+Request::getReceivedChunkDataLength() const
 {
-    return (this->_received_chunk_data_size);
+    return (this->_received_chunk_data_length);
 }
 
 int
@@ -258,9 +258,9 @@ Request::setTargetChunkSize(const int target_size)
 }
 
 void
-Request::setReceivedChunkDataSize(const int received_chunk_data_size)
+Request::setReceivedChunkDataLength(const int received_chunk_data_length)
 {
-    this->_received_chunk_data_size = received_chunk_data_size;
+    this->_received_chunk_data_length = received_chunk_data_length;
 }
 
 void
@@ -607,7 +607,7 @@ Request::init()
     this->_ip_address = "";
     this->_transfered_body_size = 0;
     this->_target_chunk_size = DEFAULT_TARGET_CHUNK_SIZE;
-    this->_received_chunk_data_size = 0;
+    this->_received_chunk_data_length = 0;
     this->_carriege_return_trimmed = false;
     this->_recv_counts = 0;
     this->_temp_buffer = "";

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -15,7 +15,8 @@ Request::Request()
 _protocol(""), _body(""), _status_code("200"),
 _info(RecvRequest::REQUEST_LINE), _ip_address(""),
 _transfered_body_size(0), _target_chunk_size(DEFAULT_TARGET_CHUNK_SIZE),
-_received_chunk_data_length(0), _recv_counts(0),
+_received_chunk_data_length(0), _index_of_crlf_in_chunk_size(-1),
+_received_chunk_size_length(0), _chunk_size(""), _recv_counts(0),
 _carriege_return_trimmed(false), _temp_buffer("")
  {}
 
@@ -25,8 +26,10 @@ _version(other._version), _headers(other._headers),
 _protocol(other._protocol), _body(other._body),
 _status_code(other._status_code), _info(other._info),
 _ip_address(other._ip_address), _transfered_body_size(other._transfered_body_size),
-_target_chunk_size(other._target_chunk_size),
-_received_chunk_data_length(other._received_chunk_data_length), _recv_counts(other._recv_counts),
+_target_chunk_size(other._target_chunk_size), _received_chunk_data_length(other._received_chunk_data_length),
+_index_of_crlf_in_chunk_size(other._index_of_crlf_in_chunk_size),
+_received_chunk_size_length(other._received_chunk_size_length),
+_chunk_size(other._chunk_size), _recv_counts(other._recv_counts),
 _carriege_return_trimmed(other._carriege_return_trimmed), _temp_buffer(other._temp_buffer)
 {}
 
@@ -45,6 +48,9 @@ Request::operator=(const Request& other)
     this->_transfered_body_size = other._transfered_body_size;
     this->_target_chunk_size = other._target_chunk_size;
     this->_received_chunk_data_length = other._received_chunk_data_length;
+    this->_index_of_crlf_in_chunk_size = other._index_of_crlf_in_chunk_size;
+    this->_received_chunk_size_length = other._received_chunk_size_length;
+    this->_chunk_size = other._chunk_size;
     this->_recv_counts = other._recv_counts;
     this->_carriege_return_trimmed = other._carriege_return_trimmed;
     this->_temp_buffer = other._temp_buffer;
@@ -149,6 +155,24 @@ int
 Request::getReceivedChunkDataLength() const
 {
     return (this->_received_chunk_data_length);
+}
+
+int
+Request::getIndexOfCRLFInChunkSize() const
+{
+    return (this->_index_of_crlf_in_chunk_size);
+}
+
+int
+Request::getReceivedChunkSizeLength() const
+{
+    return (this->_received_chunk_size_length);
+}
+
+const std::string&
+Request::getChunkSize() const
+{
+    return (this->_chunk_size);
 }
 
 int
@@ -261,6 +285,24 @@ void
 Request::setReceivedChunkDataLength(const int received_chunk_data_length)
 {
     this->_received_chunk_data_length = received_chunk_data_length;
+}
+
+void
+Request::setIndexOfCRLFInChunkSize(const int index_of_crlf_in_chunk_size)
+{
+    this->_index_of_crlf_in_chunk_size = index_of_crlf_in_chunk_size;
+}
+
+void
+Request::setReceivedChunkSizeLength(const int received_chunk_size_length)
+{
+    this->_received_chunk_size_length = received_chunk_size_length;
+}
+
+void
+Request::setChunkSize(const std::string& chunk_size)
+{
+    this->_chunk_size = chunk_size;
 }
 
 void
@@ -594,6 +636,12 @@ Request::appendTempBuffer(char* buf, int bytes)
 }
 
 void
+Request::appendChunkSize(char* buf, int bytes)
+{
+    this->_chunk_size.append(buf, bytes);
+}
+
+void
 Request::init()
 {
     this->_method = "";
@@ -608,6 +656,9 @@ Request::init()
     this->_transfered_body_size = 0;
     this->_target_chunk_size = DEFAULT_TARGET_CHUNK_SIZE;
     this->_received_chunk_data_length = 0;
+    this->_index_of_crlf_in_chunk_size = -1;
+    this->_received_chunk_size_length = 0;
+    this->_chunk_size = "";
     this->_carriege_return_trimmed = false;
     this->_recv_counts = 0;
     this->_temp_buffer = "";

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -13,9 +13,10 @@
 Request::Request()
 : _method(""), _uri(""), _version(""),
 _protocol(""), _body(""), _status_code("200"),
-_info(RecvRequest::REQUEST_LINE), _is_buffer_left(false),
-_ip_address(""), _transfered_body_size(0), _target_chunk_size(DEFAULT_TARGET_CHUNK_SIZE),
-_received_chunk_data_size(0), _recv_counts(0), _carriege_return_trimmed(false), _temp_buffer("")
+_info(RecvRequest::REQUEST_LINE), _ip_address(""),
+_transfered_body_size(0), _target_chunk_size(DEFAULT_TARGET_CHUNK_SIZE),
+_received_chunk_data_size(0), _recv_counts(0),
+_carriege_return_trimmed(false), _temp_buffer("")
  {}
 
 Request::Request(const Request& other)
@@ -23,8 +24,8 @@ Request::Request(const Request& other)
 _version(other._version), _headers(other._headers),
 _protocol(other._protocol), _body(other._body),
 _status_code(other._status_code), _info(other._info),
-_is_buffer_left(other._is_buffer_left), _ip_address(other._ip_address),
-_transfered_body_size(other._transfered_body_size), _target_chunk_size(other._target_chunk_size),
+_ip_address(other._ip_address), _transfered_body_size(other._transfered_body_size),
+_target_chunk_size(other._target_chunk_size),
 _received_chunk_data_size(other._received_chunk_data_size), _recv_counts(other._recv_counts),
 _carriege_return_trimmed(other._carriege_return_trimmed), _temp_buffer(other._temp_buffer)
 {}
@@ -40,7 +41,6 @@ Request::operator=(const Request& other)
     this->_body = other._body;
     this->_status_code = other._status_code;
     this->_info = other._info;
-    this->_is_buffer_left = other._is_buffer_left;
     this->_ip_address = other._ip_address;
     this->_transfered_body_size = other._transfered_body_size;
     this->_target_chunk_size = other._target_chunk_size;
@@ -107,12 +107,6 @@ const RecvRequest&
 Request::getRecvRequest() const
 {
     return (this->_info);
-}
-
-bool
-Request::getIsBufferLeft() const
-{
-    return (this->_is_buffer_left);
 }
 
 const std::string&
@@ -225,12 +219,6 @@ void
 Request::setRecvRequest(const RecvRequest& info)
 {
     this->_info = info;
-}
-
-void
-Request::setIsBufferLeft(const bool& is_left_buffer)
-{
-    this->_is_buffer_left = is_left_buffer;
 }
 
 void
@@ -391,13 +379,6 @@ Request::isChunkedBody() const
     if (this->getRecvRequest() == RecvRequest::COMPLETE)
         return (false);
     return (!isNormalBody());
-}
-
-
-bool
-Request::isContentLeftInBuffer() const
-{
-    return (this->getIsBufferLeft());
 }
 
 int
@@ -623,7 +604,6 @@ Request::init()
     this->_body = "";
     this->_status_code = "200";
     this->_info = RecvRequest::REQUEST_LINE;
-    this->_is_buffer_left = false;
     this->_ip_address = "";
     this->_transfered_body_size = 0;
     this->_target_chunk_size = DEFAULT_TARGET_CHUNK_SIZE;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -615,7 +615,7 @@ Server::receiveChunkData(int client_fd, int receive_size)
         // readed_bytes += bytes;
         // std::cout<<"\033[1;33m"<<"in receiveChunkData bytes: "<<bytes<<"\033[0m"<<std::endl;
         // std::cout<<"\033[1;33m"<<"in receiveChunkData readed_bytes: "<<readed_bytes<<"\033[0m"<<std::endl;
-        request.setReceivedChunkDataSize(request.getReceivedChunkDataSize() + bytes);
+        request.setReceivedChunkDataLength(request.getReceivedChunkDataLength() + bytes);
         request.parseChunkData(buf, bytes);
         // request.setRemainedChunkDataSize(receive_size - bytes);
         // if (flag == true)
@@ -625,7 +625,7 @@ Server::receiveChunkData(int client_fd, int receive_size)
         //     std::cout << "bytes: " << bytes << std::endl;
         //     std::cout << "receive_target size: " << receive_size << std::endl;
         //     std::cout << "target_chunk_size: " << request.getTargetChunkSize() << std::endl;
-        //     std::cout << "received_chunk_data_size: " << request.getReceivedChunkDataSize() << std::endl;
+        //     std::cout << "received_chunk_data_size: " << request.getReceivedChunkDataLength() << std::endl;
         // std::cout << "===============================================" << std::endl;
         // std::cout << "\033[0m";
         //     flag = false;
@@ -638,7 +638,7 @@ Server::receiveChunkData(int client_fd, int receive_size)
         //     std::cout << "bytes: " << bytes << std::endl;
         //     std::cout << "receive size: " << receive_size << std::endl;
         //     std::cout << "target_chunk_size: " << request.getTargetChunkSize() << std::endl;
-        //     std::cout << "received_chunk_data_size: " << request.getReceivedChunkDataSize() << std::endl;
+        //     std::cout << "received_chunk_data_size: " << request.getReceivedChunkDataLength() << std::endl;
         // std::cout << "request body len: " << request.getBody().length() << std::endl;
         // std::cout << "next target: " << receive_size - bytes << std::endl;
         // std::cout << "===============================================" << std::endl;
@@ -749,12 +749,12 @@ Server::receiveRequestChunkedBody(int client_fd)
             this->receiveLastChunkData(client_fd);
     else
         {
-            int receive_target_size = std::min(RECEIVE_SOCKET_STREAM_SIZE, request.getTargetChunkSize() + CRLF_SIZE - request.getReceivedChunkDataSize());
+            int receive_target_size = std::min(RECEIVE_SOCKET_STREAM_SIZE, request.getTargetChunkSize() + CRLF_SIZE - request.getReceivedChunkDataLength());
             this->receiveChunkData(client_fd, receive_target_size);
 
-            if (request.getTargetChunkSize() + CRLF_SIZE == request.getReceivedChunkDataSize())
+            if (request.getTargetChunkSize() + CRLF_SIZE == request.getReceivedChunkDataLength())
             {
-                request.setReceivedChunkDataSize(0);
+                request.setReceivedChunkDataLength(0);
                 request.setTargetChunkSize(DEFAULT_TARGET_CHUNK_SIZE);
             }
         }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -680,10 +680,7 @@ Server::receiveLastChunkData(int client_fd)
         // readed_bytes += bytes;
         // std::cout<<"\033[1;33m"<<"in receiveLastChunkData readed_bytes: "<<readed_bytes<<"\033[0m"<<std::endl;
         if (bytes != CRLF_SIZE)
-        {
-            request.setIsBufferLeft(true);
             throw (Request::RequestFormatException(request, "400"));
-        }
         if (std::string(buf).compare("\r\n") == 0)
         {
             request.setRecvRequest(RecvRequest::COMPLETE);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -374,6 +374,12 @@ Server::isExistCRLFInChunkSize(int fd)
     return (this->_requests[fd].getIndexOfCRLFInChunkSize() != -1);
 }
 
+bool
+Server::isNotYetSetTargetChunkSize(int fd)
+{
+    return (this->_requests[fd].getTargetChunkSize() == DEFAULT_TARGET_CHUNK_SIZE);
+}
+
 int
 Server::readBufferUntilRequestLine(int client_fd, char* buf, size_t line_end_pos)
 {
@@ -735,7 +741,7 @@ Server::receiveRequestChunkedBody(int client_fd)
         buf[bytes] = 0;
         if (this->isExistCRLFInChunkSize(client_fd))
             this->receiveChunkSize(client_fd, request.getIndexOfCRLFInChunkSize());
-        else if (request.getTargetChunkSize() == DEFAULT_TARGET_CHUNK_SIZE)
+        else if (this->isNotYetSetTargetChunkSize(client_fd))
         {
             if ((index_of_crlf = std::string(buf).find("\r\n")) != std::string::npos)
                 this->_requests[client_fd].setIndexOfCRLFInChunkSize(index_of_crlf);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -426,7 +426,7 @@ Server::prepareReceiveNextChunkData(int fd)
 }
 
 void
-Server::completeChunkSequence(int fd)
+Server::finishChunkSequence(int fd)
 {
     this->_requests[fd].setRecvRequest(RecvRequest::COMPLETE);
     this->_requests[fd].setLastChunkData("");
@@ -717,7 +717,7 @@ Server::receiveLastChunkData(int client_fd)
                 throw (Request::RequestFormatException(request, "400"));
             request.appendLastChunkData(buf, bytes);
             if (request.getLastChunkData().compare("\r\n") == 0)
-                this->completeChunkSequence(client_fd);
+                this->finishChunkSequence(client_fd);
             else
                 throw (Request::RequestFormatException(request, "400"));
         }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -371,7 +371,7 @@ Server::init()
 bool
 Server::isExistCRLFInChunkSize(int fd)
 {
-    return (this->_requests[fd].getIndexOfCRLFInChunkSize() != -1);
+    return (this->_requests[fd].getIndexOfCRLFInChunkSize() != DEFAULT_INDEX_OF_CRLF);
 }
 
 bool
@@ -420,7 +420,7 @@ Server::prepareReceiveNextChunkSize(int fd)
 void
 Server::prepareReceiveNextChunkData(int fd)
 {
-    this->_requests[fd].setIndexOfCRLFInChunkSize(-1);
+    this->_requests[fd].setIndexOfCRLFInChunkSize(DEFAULT_INDEX_OF_CRLF);
     this->_requests[fd].setChunkSize("");
     this->_requests[fd].setReceivedChunkSizeLength(0);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -404,6 +404,12 @@ Server::calculateReceiveTargetSizeOfChunkData(int fd)
             this->_requests[fd].getTargetChunkSize() + CRLF_SIZE - this->_requests[fd].getReceivedChunkDataLength()));
 }
 
+bool
+Server::isReceivedChunkDataToTheEnd(int fd)
+{
+    return ((this->_requests[fd].getTargetChunkSize() + CRLF_SIZE == this->_requests[fd].getReceivedChunkDataLength()));
+}
+
 int
 Server::readBufferUntilRequestLine(int client_fd, char* buf, size_t line_end_pos)
 {
@@ -772,7 +778,7 @@ Server::receiveRequestChunkedBody(int client_fd)
             int receive_target_size = this->calculateReceiveTargetSizeOfChunkData(client_fd);
             this->receiveChunkData(client_fd, receive_target_size);
 
-            if (request.getTargetChunkSize() + CRLF_SIZE == request.getReceivedChunkDataLength())
+            if (this->isReceivedChunkDataToTheEnd(client_fd))
             {
                 request.setReceivedChunkDataLength(0);
                 request.setTargetChunkSize(DEFAULT_TARGET_CHUNK_SIZE);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -391,6 +391,12 @@ Server::findCRLFInChunkSize(int fd, const std::string& buf)
         throw (Request::RequestFormatException(this->_requests[fd], "400"));
 }
 
+bool
+Server::isLastSequenceOfParsingChunk(int fd)
+{
+    return (this->_requests[fd].getTargetChunkSize() == 0);
+}
+
 int
 Server::readBufferUntilRequestLine(int client_fd, char* buf, size_t line_end_pos)
 {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -405,7 +405,7 @@ Server::calculateReceiveTargetSizeOfChunkData(int fd)
 }
 
 bool
-Server::isReceivedChunkDataToTheEnd(int fd)
+Server::isChunkDataAllReceived(int fd)
 {
     return ((this->_requests[fd].getTargetChunkSize() + CRLF_SIZE == this->_requests[fd].getReceivedChunkDataLength()));
 }
@@ -755,7 +755,7 @@ Server::receiveRequestChunkedBody(int client_fd)
         {
             int receive_target_size = this->calculateReceiveTargetSizeOfChunkData(client_fd);
             this->receiveChunkData(client_fd, receive_target_size);
-            if (this->isReceivedChunkDataToTheEnd(client_fd))
+            if (this->isChunkDataAllReceived(client_fd))
                 this->prepareToReceiveNextChunkSize(client_fd);
         }
     }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -410,6 +410,13 @@ Server::isReceivedChunkDataToTheEnd(int fd)
     return ((this->_requests[fd].getTargetChunkSize() + CRLF_SIZE == this->_requests[fd].getReceivedChunkDataLength()));
 }
 
+void
+Server::prepareReceiveNextChunkSize(int fd)
+{
+    this->_requests[fd].setReceivedChunkDataLength(0);
+    this->_requests[fd].setTargetChunkSize(DEFAULT_TARGET_CHUNK_SIZE);
+}
+
 int
 Server::readBufferUntilRequestLine(int client_fd, char* buf, size_t line_end_pos)
 {
@@ -777,12 +784,8 @@ Server::receiveRequestChunkedBody(int client_fd)
         {
             int receive_target_size = this->calculateReceiveTargetSizeOfChunkData(client_fd);
             this->receiveChunkData(client_fd, receive_target_size);
-
             if (this->isReceivedChunkDataToTheEnd(client_fd))
-            {
-                request.setReceivedChunkDataLength(0);
-                request.setTargetChunkSize(DEFAULT_TARGET_CHUNK_SIZE);
-            }
+                this->prepareReceiveNextChunkSize(client_fd);
         }
     }
     else if (bytes == RECV_COUNT_NOT_REACHED)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -368,6 +368,12 @@ Server::init()
     this->_server_manager->updateFdMax(this->_server_socket);
 }
 
+bool
+Server::isExistCRLFInChunkSize(int fd)
+{
+    return (this->_requests[fd].getIndexOfCRLFInChunkSize() != -1);
+}
+
 int
 Server::readBufferUntilRequestLine(int client_fd, char* buf, size_t line_end_pos)
 {
@@ -727,7 +733,7 @@ Server::receiveRequestChunkedBody(int client_fd)
     if ((bytes = request.peekMessageFromClient(client_fd, buf)) > 0)
     {
         buf[bytes] = 0;
-        if (this->_requests[client_fd].getIndexOfCRLFInChunkSize() != -1)
+        if (this->isExistCRLFInChunkSize(client_fd))
             this->receiveChunkSize(client_fd, request.getIndexOfCRLFInChunkSize());
         else if (request.getTargetChunkSize() == DEFAULT_TARGET_CHUNK_SIZE)
         {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -622,7 +622,7 @@ Server::receiveRequestNormalBody(int client_fd)
 }
 
 void
-Server::receiveChunkSize(int client_fd, size_t index_of_crlf)
+Server::receiveChunkSize(int client_fd)
 {
     Log::trace("> receiveChunkSize", 1);
     timeval from;
@@ -632,6 +632,7 @@ Server::receiveChunkSize(int client_fd, size_t index_of_crlf)
     char buf[RECEIVE_SOCKET_STREAM_SIZE + 1];
     Request& request = this->_requests[client_fd];
 
+    int index_of_crlf = request.getIndexOfCRLFInChunkSize();
     int received_chunk_size_length = request.getReceivedChunkSizeLength();
 
     if ((bytes = recv(client_fd, buf, index_of_crlf + CRLF_SIZE, 0)) > 0)
@@ -745,7 +746,7 @@ Server::receiveRequestChunkedBody(int client_fd)
     {
         buf[bytes] = 0;
         if (this->isExistCRLFInChunkSize(client_fd))
-            this->receiveChunkSize(client_fd, request.getIndexOfCRLFInChunkSize());
+            this->receiveChunkSize(client_fd);
         else if (this->isNotYetSetTargetChunkSize(client_fd))
             this->findCRLFInChunkSize(client_fd, buf);
         else if (this->isLastSequenceOfParsingChunk(client_fd))

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -617,8 +617,7 @@ Server::receiveChunkSize(int client_fd, size_t index_of_crlf)
 
     int received_chunk_size_length = request.getReceivedChunkSizeLength();
 
-    // if ((bytes = recv(client_fd, buf, index_of_crlf + CRLF_SIZE, 0)) > 0)
-    if ((bytes = recv(client_fd, buf, 1, 0)) > 0)
+    if ((bytes = recv(client_fd, buf, index_of_crlf + CRLF_SIZE, 0)) > 0)
     {
         buf[bytes] = 0;
         received_chunk_size_length += bytes;
@@ -626,7 +625,7 @@ Server::receiveChunkSize(int client_fd, size_t index_of_crlf)
 
         if (received_chunk_size_length == static_cast<int>(index_of_crlf) + CRLF_SIZE)
         {
-            request.appendChunkSize(buf, bytes); //NOTE: CRLF가 포함된 버퍼가 stoiHex로 들어가도 문제없음 확인
+            request.appendChunkSize(buf, bytes);
             request.parseTargetChunkSize(request.getChunkSize());
             request.setIndexOfCRLFInChunkSize(-1);
             request.setChunkSize("");
@@ -644,8 +643,6 @@ Server::receiveChunkSize(int client_fd, size_t index_of_crlf)
     Log::trace("< receiveChunkSize", 1);
 }
 
-// bool flag;
-
 void
 Server::receiveChunkData(int client_fd, int receive_size)
 {
@@ -658,50 +655,14 @@ Server::receiveChunkData(int client_fd, int receive_size)
     char buf[RECEIVE_SOCKET_STREAM_SIZE + 1];
     Request& request = this->_requests[client_fd];
 
-    // ft::memset(buf, 0, RECEIVE_SOCKET_STREAM_SIZE + 1);
     if ((bytes = recv(client_fd, buf, receive_size, 0)) > 0)
     {
         buf[bytes] = 0;
-        // readed_bytes += bytes;
-        // std::cout<<"\033[1;33m"<<"in receiveChunkData bytes: "<<bytes<<"\033[0m"<<std::endl;
-        // std::cout<<"\033[1;33m"<<"in receiveChunkData readed_bytes: "<<readed_bytes<<"\033[0m"<<std::endl;
         request.setReceivedChunkDataLength(request.getReceivedChunkDataLength() + bytes);
         request.parseChunkData(buf, bytes);
-        // request.setRemainedChunkDataSize(receive_size - bytes);
-        // if (flag == true)
-        // {
-        //     std::cout << "\033[33m\033[01m";
-        // std::cout << "===============================================" << std::endl;
-        //     std::cout << "bytes: " << bytes << std::endl;
-        //     std::cout << "receive_target size: " << receive_size << std::endl;
-        //     std::cout << "target_chunk_size: " << request.getTargetChunkSize() << std::endl;
-        //     std::cout << "received_chunk_data_size: " << request.getReceivedChunkDataLength() << std::endl;
-        // std::cout << "===============================================" << std::endl;
-        // std::cout << "\033[0m";
-        //     flag = false;
-        // }
-
-        // std::cout << "\033[35m\033[01m";
-        // if (bytes != receive_size)
-        // {
-        // std::cout << "===============================================" << std::endl;
-        //     std::cout << "bytes: " << bytes << std::endl;
-        //     std::cout << "receive size: " << receive_size << std::endl;
-        //     std::cout << "target_chunk_size: " << request.getTargetChunkSize() << std::endl;
-        //     std::cout << "received_chunk_data_size: " << request.getReceivedChunkDataLength() << std::endl;
-        // std::cout << "request body len: " << request.getBody().length() << std::endl;
-        // std::cout << "next target: " << receive_size - bytes << std::endl;
-        // std::cout << "===============================================" << std::endl;
-        // flag = true;
-        // // sleep(100);
-        // }
-        // std::cout << "\033[0m";
     }
     else if (bytes == 0)
-    {
-        // std::cout<<"\033[1;31m"<<"received Bytes: 0"<<"\033[0m"<<std::endl;
         this->closeClientSocket(client_fd);
-    }
     else
         throw (UnchunkedErrorException());
 
@@ -723,8 +684,7 @@ Server::receiveLastChunkData(int client_fd)
 
     int received_last_chunk_data_length = request.getReceivedLastChunkDataLength();
 
-    // bytes = recv(client_fd, buf, CRLF_SIZE + 1, 0);
-    bytes = recv(client_fd, buf, 1, 0);
+    bytes = recv(client_fd, buf, CRLF_SIZE + 1, 0);
     if (bytes > 0)
     {
         buf[bytes] = 0;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -411,14 +411,14 @@ Server::isReceivedChunkDataToTheEnd(int fd)
 }
 
 void
-Server::prepareReceiveNextChunkSize(int fd)
+Server::prepareToReceiveNextChunkSize(int fd)
 {
     this->_requests[fd].setReceivedChunkDataLength(0);
     this->_requests[fd].setTargetChunkSize(DEFAULT_TARGET_CHUNK_SIZE);
 }
 
 void
-Server::prepareReceiveNextChunkData(int fd)
+Server::prepareToReceiveNextChunkData(int fd)
 {
     this->_requests[fd].setIndexOfCRLFInChunkSize(DEFAULT_INDEX_OF_CRLF);
     this->_requests[fd].setChunkSize("");
@@ -645,7 +645,7 @@ Server::receiveChunkSize(int client_fd)
         {
             request.appendChunkSize(buf, bytes);
             request.parseTargetChunkSize(request.getChunkSize());
-            this->prepareReceiveNextChunkData(client_fd);
+            this->prepareToReceiveNextChunkData(client_fd);
         }
         else
             request.appendChunkSize(buf, bytes);
@@ -756,7 +756,7 @@ Server::receiveRequestChunkedBody(int client_fd)
             int receive_target_size = this->calculateReceiveTargetSizeOfChunkData(client_fd);
             this->receiveChunkData(client_fd, receive_target_size);
             if (this->isReceivedChunkDataToTheEnd(client_fd))
-                this->prepareReceiveNextChunkSize(client_fd);
+                this->prepareToReceiveNextChunkSize(client_fd);
         }
     }
     else if (bytes == RECV_COUNT_NOT_REACHED)


### PR DESCRIPTION
# Fix/receiveChunkSizeAndReceiveLastChunk

## 1. 문제
    receiveChunkSize와 receiveLastChunkData 함수에서 읽어야 할 만큼의 사이즈를 읽을 수 있도록 보장하지 않고 있었던 문제.

## 2. 원인

    std::string의 최댓값 약 42억 정도의 데이터가 Transfer-Encoding: chunked로, 그리고 한 번에 42억 정도의 Chunk Size로 request가 왔다고 했을 때, 16진수로 42억은 대략 FA56EA00이다. 따라서 우리 서버에서 감당할 수 있는 최대 Chunk Size의 길이는 해봤자 8글자 + CR+LF 총 10바이트 정도였을 것이다. 일단 기존에는 이것이 매우 적은 양이기 때문에 한 번에 읽지 못할 경우를 상정하지 않았었고, 실제 여러 테스트를 해보았을 때 ChunkSize를 아무리 키워도 여러 번에 나누어 읽는 경우가 전혀 나타나지 않았음.

    하지만, TCP 소켓의 특성상 예를들어 10000\r\n 이라는 청크사이즈가 도착했을 때, recv를 하면 한 번에 10000\r\n을 읽지 못할 수도 있다. 만약 1000(4바이트) 만큼을 먼저 읽고 그 이후에 0\r\n을 만났을 때 아 청크 리퀘스트가 끝났구나 하는 불상사가 발생할 수 있음... 따라서 Chunk Size와 Last Chunk 부분에서 한 번에 읽지 못한 경우를 고려하여 보정하였음.

    - 테스트가 매우 힘들었는데, 임의로 버퍼사이즈를 1 또는 2로 조정하면서 읽게 했고, 수정 후 적절하게 append 되면서 처리가 되는 것을 확인했음. 
    - 1글자씩 읽었을 때 \r 과 \n을 따로 읽고 같이 읽고 이 경우 저 경우 모두 다 해결이 되는 것을 확인했습니다!

## 3. 해결

    지금까지 작업과 마찬가지로, transfered 를 계산하여 우리가 의도한 만큼을 읽었을 때만 다음 분기로 넘어가게끔 조정하였음.