### PR TITLE
Feat/decoding uri

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -36,6 +36,7 @@ private:
     std::string _uri_path;
     std::string _uri_extension;
     std::string _transmitting_body;
+    std::string _query;
 
     size_t _already_encoded_size;
 
@@ -93,6 +94,7 @@ public:
     const std::string& getResponseMessage() const;
     const SendProgress& getSendProgress() const;
     const std::string& getTempBuffer() const;
+    const std::string& getQuery() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
@@ -102,6 +104,7 @@ public:
     void setResourceType(const ResType& resource_type);
     void setBody(const std::string& body);
     void setUriPath(const std::string& path);
+    void setQuery(const std::string& query);
     void setUriExtension(const std::string& extension);
     void setHeaders(const std::string& key, const std::string& value);
 

--- a/include/UriParser.hpp
+++ b/include/UriParser.hpp
@@ -52,7 +52,8 @@ public:
     /* Exception */
     /* Util */
     void init();
-    void parseUri(const std::string& uri);
+    bool decodingUri(std::string& uri);
+    bool parseUri(const std::string& uri);
     std::string findScheme();
     std::string findPort();
     std::string findHostAndPort();

--- a/include/UriParser.hpp
+++ b/include/UriParser.hpp
@@ -20,7 +20,6 @@ private:
     std::string _port;
     std::string _path;
     std::string _query;
-    std::vector<std::string> _paths;
         
 public:
     /* Constructor */
@@ -37,7 +36,6 @@ public:
     const std::string& getHost() const;
     const std::string& getPort() const;
     const std::string& getPath() const;
-    const std::vector<std::string>& getPaths() const;
     const std::string& getQuery() const;
     /* Setter */
     void setIndex(int index);

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -21,7 +21,7 @@ _location_info(), _resource_abs_path(""), _route(""),
 _directory_entry(""), _resource_type(ResType::NOT_YET_CHECKED), _body(""),
 _stdin_of_cgi(DEFAULT_FD), _stdout_of_cgi(DEFAULT_FD), _read_fd_from_cgi(DEFAULT_FD),
 _write_fd_to_cgi(DEFAULT_FD),  _cgi_pid(DEFAULT_FD), _uri_path(""), _uri_extension(""), _transmitting_body(""),
-_already_encoded_size(0), _parse_progress(ParseProgress::DEFAULT),
+_query(""), _already_encoded_size(0), _parse_progress(ParseProgress::DEFAULT),
 _receive_progress(ReceiveProgress::DEFAULT), _resource_fd(DEFAULT_FD),
 _sended_response_size(0), _response_message(""), _send_progress(SendProgress::READY),
 _temp_buffer("")
@@ -41,7 +41,8 @@ _file_info(other._file_info), _resource_type(other._resource_type),
 _body(other._body), _stdin_of_cgi(other._stdout_of_cgi),
 _stdout_of_cgi(other._stdout_of_cgi), _read_fd_from_cgi(other._read_fd_from_cgi),
 _write_fd_to_cgi(other._write_fd_to_cgi), _cgi_pid(other._cgi_pid),
-_uri_path(other._uri_path), _uri_extension(other._uri_extension), _transmitting_body(other._transmitting_body),
+_uri_path(other._uri_path), _uri_extension(other._uri_extension),
+_transmitting_body(other._transmitting_body), _query(other._query), 
 _already_encoded_size(other._already_encoded_size), _parse_progress(other._parse_progress),
 _receive_progress(other._receive_progress), _resource_fd(other._resource_fd),
 _sended_response_size(other._sended_response_size), _response_message(other._response_message),
@@ -84,6 +85,7 @@ Response::operator=(const Response& rhs)
     this->_uri_path = rhs._uri_path;
     this->_uri_extension = rhs._uri_extension;
     this->_transmitting_body = rhs._transmitting_body;
+    this->_query = rhs._query;
     this->_already_encoded_size = rhs._already_encoded_size;
     this->_parse_progress = rhs._parse_progress;
     this->_receive_progress = rhs._receive_progress;
@@ -211,6 +213,12 @@ const std::string&
 Response::getTransmittingBody() const
 {
     return (this->_transmitting_body);
+}
+
+const std::string&
+Response::getQuery() const
+{
+    return (this->_query);
 }
 
 const ParseProgress&
@@ -358,6 +366,12 @@ Response::setTransmittingBody(const std::string& transmitting_body)
 }
 
 void
+Response::setQuery(const std::string& query)
+{
+    this->_query = query;
+}
+
+void
 Response::setAlreadyEncodedSize(const size_t already_encoded_size)
 {
     this->_already_encoded_size = already_encoded_size;
@@ -465,6 +479,7 @@ Response::init()
     this->_uri_path = "";
     this->_uri_extension = "";
     this->_transmitting_body = "";
+    this->_query = "";
     this->_already_encoded_size = 0;
     this->_parse_progress = ParseProgress::DEFAULT;
     this->_receive_progress = ReceiveProgress::DEFAULT;

--- a/srcs/UriParser.cpp
+++ b/srcs/UriParser.cpp
@@ -230,7 +230,10 @@ UriParser::findAndSetQuery(const std::string& path)
         this->setQuery("");
     else
     {
-        this->setQuery(path.substr(index));
+        if (path.length() > index + 1)
+            this->setQuery(path.substr(index + 1));
+        else
+            this->setQuery("");
         this->setPath(path.substr(0, index));
     }
 }

--- a/srcs/UriParser.cpp
+++ b/srcs/UriParser.cpp
@@ -58,12 +58,6 @@ UriParser::getPath() const
     return (this->_path);
 }
 
-const std::vector<std::string>&
-UriParser::getPaths() const
-{
-    return (this->_paths);
-}
-
 const std::string&
 UriParser::getQuery() const
 {
@@ -247,7 +241,6 @@ UriParser::init()
     this->_port.clear();
     this->_path.clear();
     this->_query.clear();
-    this->_paths.clear();
 }
 
 void

--- a/srcs/UriParser.cpp
+++ b/srcs/UriParser.cpp
@@ -155,10 +155,32 @@ UriParser::setQuery(const std::string& query)
 /*********************************  Util  *************************************/
 /*============================================================================*/
 
-void
+bool
+UriParser::decodingUri(std::string& uri)
+{
+    size_t target_index = 0;
+    while ((target_index = uri.find('+', target_index)) != std::string::npos)
+        uri.replace(target_index, 1, " ");
+    target_index = 0;
+    while ((target_index = uri.find('%', target_index)) != std::string::npos)
+    {
+        std::string hex = uri.substr(target_index + 1, 2);
+        int base10 = ft::stoiHex(hex);
+        if (base10 < 31 || base10 >= 127)
+            return (false);
+        uri.replace(target_index, 3, 1, static_cast<unsigned char>(base10));
+        target_index += 1;
+    }
+    return (true);
+}
+
+bool
 UriParser::parseUri(const std::string& uri)
 {
-    this->setUri(uri);
+    std::string parsed_uri(uri);
+    if (this->decodingUri(parsed_uri) == false)
+        return (false);
+    this->setUri(parsed_uri);
     this->setScheme(this->findScheme());
     const std::string& host_port = this->findHostAndPort();
     size_t index = this->getIndex();
@@ -174,6 +196,7 @@ UriParser::parseUri(const std::string& uri)
         this->setPaths();
     }
     this->findAndSetQuery(this->getPath());
+    return (true);
 }
 
 std::string

--- a/srcs/UriParser.cpp
+++ b/srcs/UriParser.cpp
@@ -126,22 +126,6 @@ UriParser::setHostAndPort(const std::string& host_port)
 }
 
 void
-UriParser::setPaths()
-{
-    size_t i = 0;
-    if (this->_path == "/")
-    {
-        this->_paths.push_back("/");
-        return ;
-    }
-    this->_paths = ft::split(this->_path, "/");
-    for (; i < this->_paths.size() - 1; i++)
-        this->_paths[i].append("/");
-    if (this->_uri.back() == '/')
-        this->_paths[i].append("/");
-}
-
-void
 UriParser::setQuery(const std::string& query)
 {
     this->_query = query;
@@ -186,15 +170,9 @@ UriParser::parseUri(const std::string& uri)
     size_t index = this->getIndex();
     this->setHostAndPort(host_port);
     if (index == std::string::npos || this->_uri.size() == index)
-    {
         this->setPath("/");
-        this->setPaths();
-    }
     else
-    {
         this->setPath(this->findPath());
-        this->setPaths();
-    }
     this->findAndSetQuery(this->getPath());
     return (true);
 }
@@ -221,8 +199,7 @@ UriParser::findHostAndPort()
 
     if (this->_uri[this->_index] == '/')
     {
-        // this->setIndex(this->_index + 1); // NOTE
-        this->setIndex(this->_index); // NOTE
+        this->setIndex(this->_index);
         return ("");
     }
     found = this->_uri.find("/", this->_index);
@@ -231,8 +208,7 @@ UriParser::findHostAndPort()
         this->setIndex(found);
         return (this->_uri.substr(temp_index));
     }
-    // this->setIndex(found + 1); // NOTE
-    this->setIndex(found); // NOTE
+    this->setIndex(found);
     return (this->_uri.substr(temp_index, found - temp_index));
 }
 


### PR DESCRIPTION
## 문제

URI 파싱에 `퍼센트 인코딩`이 적용되어 있지 않았었습니다.
만약 클라이언트가 URI로 `localhost:8080/one%20space` 와 같이 요청한다면 서버는 이를 `localhost:8080/one space`  와 같이 디코딩 하는 작업을 거쳐야 합니다.

## 해결

디코딩 하는 작업을 추가했습니다. 순서는 아래와 같습니다.
```
1. URI에서 % 를 찾는다.
2. %HH 를 stoiHex를 통해 10진수의 값으로 변환시킨다.
3. 그리고 std::string 의 replace 메써드를 이용해서 %HH 값을 변환된 INT의 char로 치환해줍니다.
4. 작업하는 과정에서 에러가 생긴다면 false 를 return 하고 파싱을 진행하는 main-loop에서 throw를 던집니다.
```

## 그외
- response에 query를 추가했습니다.