### PR TITLE
FIX: delete status code

### DIFF
--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -869,11 +869,11 @@ Response::appendContentLanguageHeader(std::string& headers)
 void
 Response::appendContentLengthHeader(std::string& headers, const std::string& method)
 {
-    headers += "Content-Length: ";
     if (this->getStatusCode() == "204" ||
         this->getStatusCode().front() == '1' ||
         (method == "CONNECT" && this->getStatusCode().front() == '2'))
         return ;
+    headers += "Content-Length: ";
     headers += std::to_string(this->getTransmittingBody().length());
     headers += "\r\n";
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1875,7 +1875,6 @@ Server::deleteResourceOfUri(int client_fd, const std::string& path)
         else
             throw (CannotOpenDirectoryException(*this, client_fd, "404", errno));
     }
-    response.setStatusCode("204");
 
     Log::printTimeDiff(from, 2);
     Log::trace("< deleteResourceOfUri", 2);


### PR DESCRIPTION
### 문제)
delete 메소드를 실행시키면 제대로된 응답이 발송되지 않았습니다.

### 원인)
`DELETE`를 실행시키면 무조건 204 상태코드가 셋팅되고 있도록 구현되어있었고, 이 경우 `Content-Length` 헤더가 잘못된 값으로 셋팅되고 있었기 때문입니다.

### 해결)
204 상태코드가 셋팅될 경우 `Content-Length`가 셋팅되지 않도록 수정하였습니다.
오류 수정과 별개로 하단 RFC 7231의 설명에 따라 `DELETE`  메소드 실행시 200 상태코드가 셋팅되도록 수정하였습니다.

Delete status code should be set "200" if action has been enacted and
the response message includes a representation describing the status.

- 공백이 포함된 파일도 잘 삭제되는 것을 확인하였습니다.