### PR TITLE
Refactor/response

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -114,6 +114,7 @@ public:
     bool isBodyUnnecessary() const;
     bool isNormalBody() const;
     bool isChunkedBody() const;
+    bool isConnectionHeaderClose() const;
 
     int peekMessageFromClient(int client_fd, char* buf);
     void raiseRecvCounts();

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -40,12 +40,14 @@ private:
     bool _carriege_return_trimmed;
     std::string _temp_buffer;
 
+private:
+    Request(const Request& other);
+    /* Overload */
+    Request& operator=(const Request& rhs);
 
 public:
     /* Constructor */
     Request();
-    Request(const Request& other);
-    Request& operator=(const Request& rhs);
 
     /* Destructor */
     virtual ~Request();

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -9,7 +9,8 @@
 //NOTE: test용으로 ostream include함.
 #include <iostream>
 
-# define RECV_COUNT_NOT_REACHED -2
+const int RECV_COUNT_NOT_REACHED = -2;
+const int MAXIMUM_NUMBER_OF_MSG_PEEK_FOR_FULL_RECEPTION = 50;
 
 class Request
 {

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -216,6 +216,7 @@ public:
     void appendConnectionHeader(std::string& headers, Request& request);
 
     /* Entity header */
+    void appendEntityHeaders(std::string& headers, Request& request);
     void appendAllowHeader(std::string& headers);
     void appendContentLanguageHeader(std::string& headers);
     void appendContentLengthHeader(std::string& headers, const std::string& method);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -222,6 +222,9 @@ public:
     void appendContentLengthHeader(std::string& headers, const std::string& method);
     void appendContentLocationHeader(std::string& headers);
     void appendContentTypeHeader(std::string& headers);
+
+    /* Respones header */
+    void appendResponseHeaders(std::string& headers, Request& request);
     void appendLastModifiedHeader(std::string& headers);
     void appendLocationHeader(std::string& headers, const Request& request);
     void appendRetryAfterHeader(std::string& headers, const std::string& status_code);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -22,8 +22,6 @@ private:
     std::vector<std::string> _directory_entry;
     struct stat _file_info;
     ResType _resource_type;
-    ParseProgress _parse_progress;
-    ReceiveProgress _receive_progress;
     std::string _body;
 
     int _stdin_of_cgi;
@@ -40,6 +38,9 @@ private:
 
     size_t _already_encoded_size;
 
+    ParseProgress _parse_progress;
+    ReceiveProgress _receive_progress;
+
     int _resource_fd;
     int _sended_response_size;
     std::string _response_message;
@@ -50,16 +51,18 @@ private:
     std::string _script_name;
     std::string _path_translated;
     std::string _request_uri_for_cgi;
+
+private:
+    Response(const Response& other);
+    /* Overload */
+    Response& operator=(const Response& rhs);
 public:
     /* Constructor */
     Response();
-    Response(const Response& other);
 
     /* Destructor */
     virtual ~Response();
 
-    /* Overload */
-    Response& operator=(const Response& rhs);
     /* Getter */
     const std::string& getStatusCode() const;
     const std::string& getStatusMessage(const std::string& code);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -210,8 +210,10 @@ public:
     void trimPhpCgiFirstHeadersFromTempBuffer();
 
     /* General header */
+    void appendGeneralHeaders(std::string& headers, Request& request);
     void appendDateHeader(std::string& headers);
     void appendServerHeader(std::string& headers);
+    void appendConnectionHeader(std::string& headers, Request& request);
 
     /* Entity header */
     void appendAllowHeader(std::string& headers);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -14,8 +14,6 @@ class Response
 private:
     std::string _status_code;
     std::map<std::string, std::string> _headers;
-    std::string _transfer_type;
-    std::string _clients;
     std::map<std::string, std::string> _status_code_table;
     std::map<std::string, std::string> _mime_type_table;
     location_info _location_info;
@@ -24,6 +22,8 @@ private:
     std::vector<std::string> _directory_entry;
     struct stat _file_info;
     ResType _resource_type;
+    ParseProgress _parse_progress;
+    ReceiveProgress _receive_progress;
     std::string _body;
 
     int _stdin_of_cgi;
@@ -39,9 +39,6 @@ private:
     std::string _query;
 
     size_t _already_encoded_size;
-
-    ParseProgress _parse_progress;
-    ReceiveProgress _receive_progress;
 
     int _resource_fd;
     int _sended_response_size;
@@ -67,9 +64,6 @@ public:
     const std::string& getStatusCode() const;
     const std::string& getStatusMessage(const std::string& code);
     const std::string& getRoute() const;
-    // std::string getHeaders() const;
-    // std::string getTransferType() const;
-    // std::string getClients() const;
     const location_info& getLocationInfo() const;
     const std::string& getResourceAbsPath() const;
     const std::vector<std::string>& getDirectoryEntry() const;
@@ -77,7 +71,6 @@ public:
     const ResType& getResourceType() const;
     const std::string& getBody() const;
     const std::string& getUriPath() const;
-    // int getCgiPipeFd() const;
     const std::map<std::string, std::string>& getMimeTypeTable() const;
     const std::string& getUriExtension() const;
     int getStdinOfCgi() const;
@@ -171,11 +164,10 @@ public:
         virtual const char* what() const throw();
     };
     /* Util */
-    // bool isLocationUri(const std::string& uri, Server* server);
     bool setRouteAndLocationInfo(const std::string& uri, Server* server);
     bool isLimitExceptInLocation();
     bool isAllowedMethod(const std::string& method);
-    bool isExtensionExist(const std::string& extension) const;
+    bool ExtensionExists(const std::string& extension) const;
     bool isExtensionInMimeTypeTable(const std::string& extension) const;
     void findAndSetUriExtension();
     bool isNeedToBeChunkedBody(const Request& request) const;
@@ -199,11 +191,12 @@ public:
     void init();
     void initStatusCodeTable();
     void initMimeTypeTable();
+
+    std::string makeStatusLine();
+    std::string makeHeaders(Request& request);
     void makeBody(Request& request);
     void makeTraceBody(const Request& request);
     void makeOptionBody();
-    std::string makeHeaders(Request& request);
-    std::string makeStatusLine();
 
     void appendBody(char* buf, int bytes);
     void appendTempBuffer(char* buf, int bytes);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -500,8 +500,8 @@ int
 Request::peekMessageFromClient(int client_fd, char* buf)
 {
     int bytes = recv(client_fd, buf, BUFFER_SIZE, MSG_PEEK);
-    //TODO 50은 임의값임. 최적값 찾아서 매크로상수화할 것.
-    if (bytes <= 0 || bytes == BUFFER_SIZE || this->getReceiveCounts() == 50)
+    if (bytes <= 0 || bytes == BUFFER_SIZE ||
+        this->getReceiveCounts() == MAXIMUM_NUMBER_OF_MSG_PEEK_FOR_FULL_RECEPTION)
     {
         this->setReceiveCounts(0);
         return (bytes);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -488,6 +488,14 @@ Request::isChunkedBody() const
     return (!isNormalBody());
 }
 
+bool
+Request::isConnectionHeaderClose() const
+{
+    if (this->_headers.find("Connection") == this->_headers.end())
+        return (false);
+    return (this->_headers.at("Connection") == "close");
+}
+
 int
 Request::peekMessageFromClient(int client_fd, char* buf)
 {

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -20,48 +20,6 @@ _received_request_line_length(0), _index_of_crlf_in_request_line(DEFAULT_INDEX_O
 _recv_counts(0), _carriege_return_trimmed(false), _temp_buffer("")
  {}
 
-Request::Request(const Request& other)
-: _method(other._method), _uri(other._uri), 
-_version(other._version), _headers(other._headers),
-_protocol(other._protocol), _body(other._body),
-_status_code(other._status_code), _info(other._info),
-_ip_address(other._ip_address), _transfered_body_size(other._transfered_body_size),
-_target_chunk_size(other._target_chunk_size), _received_chunk_data_length(other._received_chunk_data_length),
-_index_of_crlf_in_chunk_size(other._index_of_crlf_in_chunk_size),
-_received_chunk_size_length(other._received_chunk_size_length),
-_received_last_chunk_data_length(other._received_last_chunk_data_length),
-_received_request_line_length(other._received_request_line_length),
-_index_of_crlf_in_request_line(other._index_of_crlf_in_request_line),
-_recv_counts(other._recv_counts),
-_carriege_return_trimmed(other._carriege_return_trimmed), _temp_buffer(other._temp_buffer)
-{}
-
-Request&
-Request::operator=(const Request& other)
-{
-    this->_method = other._method;
-    this->_uri = other._uri;
-    this->_version = other._version;
-    this->_headers = other._headers;
-    this->_protocol = other._protocol;
-    this->_body = other._body;
-    this->_status_code = other._status_code;
-    this->_info = other._info;
-    this->_ip_address = other._ip_address;
-    this->_transfered_body_size = other._transfered_body_size;
-    this->_target_chunk_size = other._target_chunk_size;
-    this->_received_chunk_data_length = other._received_chunk_data_length;
-    this->_index_of_crlf_in_chunk_size = other._index_of_crlf_in_chunk_size;
-    this->_received_chunk_size_length = other._received_chunk_size_length;
-    this->_received_last_chunk_data_length = other._received_last_chunk_data_length;
-    this->_received_request_line_length = other._received_request_line_length;
-    this->_index_of_crlf_in_request_line = other._index_of_crlf_in_request_line;
-    this->_recv_counts = other._recv_counts;
-    this->_carriege_return_trimmed = other._carriege_return_trimmed;
-    this->_temp_buffer = other._temp_buffer;
-    return (*this);
-}
-
 /*============================================================================*/
 /******************************  Destructor  **********************************/
 /*============================================================================*/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -32,25 +32,6 @@ _request_uri_for_cgi("")
     this->initMimeTypeTable();
 }
 
-Response::Response(const Response& other)
-: _status_code(other._status_code), _headers(other._headers),
-_status_code_table(other._status_code_table), _mime_type_table(other._mime_type_table),
-_location_info(other._location_info), _resource_abs_path(other._resource_abs_path),
-_route(other._route), _directory_entry(other._directory_entry),
-_file_info(other._file_info), _resource_type(other._resource_type),
-_body(other._body), _stdin_of_cgi(other._stdout_of_cgi),
-_stdout_of_cgi(other._stdout_of_cgi), _read_fd_from_cgi(other._read_fd_from_cgi),
-_write_fd_to_cgi(other._write_fd_to_cgi), _cgi_pid(other._cgi_pid),
-_uri_path(other._uri_path), _uri_extension(other._uri_extension),
-_transmitting_body(other._transmitting_body), _query(other._query), 
-_already_encoded_size(other._already_encoded_size), _parse_progress(other._parse_progress),
-_receive_progress(other._receive_progress), _resource_fd(other._resource_fd),
-_sended_response_size(other._sended_response_size), _response_message(other._response_message),
-_send_progress(other._send_progress), _temp_buffer(other._temp_buffer), _path_info(other._path_info),
-_script_name(other._script_name), _path_translated(other._path_translated), 
-_request_uri_for_cgi(other._request_uri_for_cgi)
-{}
-
 /*============================================================================*/
 /******************************  Destructor  **********************************/
 /*============================================================================*/
@@ -62,44 +43,6 @@ Response::~Response()
 /*============================================================================*/
 /*******************************  Overload  ***********************************/
 /*============================================================================*/
-
-Response&
-Response::operator=(const Response& rhs)
-{
-    this->_status_code = rhs._status_code;
-    this->_headers = rhs._headers;
-    this->_status_code_table = rhs._status_code_table;
-    this->_mime_type_table = rhs._mime_type_table;
-    this->_location_info = rhs._location_info;
-    this->_resource_abs_path = rhs._resource_abs_path;
-    this->_route = rhs._route;
-    this->_directory_entry = rhs._directory_entry;
-    this->_file_info = rhs._file_info;
-    this->_resource_type = rhs._resource_type;
-    this->_body = rhs._body;
-    this->_stdin_of_cgi = rhs._stdin_of_cgi;
-    this->_stdout_of_cgi = rhs._stdout_of_cgi;
-    this->_read_fd_from_cgi = rhs._read_fd_from_cgi;
-    this->_write_fd_to_cgi = rhs._write_fd_to_cgi;
-    this->_cgi_pid = rhs._cgi_pid;
-    this->_uri_path = rhs._uri_path;
-    this->_uri_extension = rhs._uri_extension;
-    this->_transmitting_body = rhs._transmitting_body;
-    this->_query = rhs._query;
-    this->_already_encoded_size = rhs._already_encoded_size;
-    this->_parse_progress = rhs._parse_progress;
-    this->_receive_progress = rhs._receive_progress;
-    this->_resource_fd = rhs._resource_fd;
-    this->_sended_response_size = rhs._sended_response_size;
-    this->_response_message = rhs._response_message;
-    this->_send_progress = rhs._send_progress;
-    this->_temp_buffer = rhs._temp_buffer;
-    this->_path_info = rhs._path_info;
-    this->_script_name = rhs._script_name;
-    this->_path_translated = rhs._path_translated;
-    this->_request_uri_for_cgi = rhs._request_uri_for_cgi;
-    return (*this);
-}
 
 /*============================================================================*/
 /********************************  Getter  ************************************/

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -16,7 +16,7 @@
 */
 
 Response::Response()
-: _status_code("200"), _headers(), _transfer_type(""), _clients(""),
+: _status_code("200"), _headers(),
 _location_info(), _resource_abs_path(""), _route(""),
 _directory_entry(), _resource_type(ResType::NOT_YET_CHECKED), _body(""),
 _stdin_of_cgi(DEFAULT_FD), _stdout_of_cgi(DEFAULT_FD), _read_fd_from_cgi(DEFAULT_FD),
@@ -34,7 +34,6 @@ _request_uri_for_cgi("")
 
 Response::Response(const Response& other)
 : _status_code(other._status_code), _headers(other._headers),
-_transfer_type(other._transfer_type), _clients(other._clients),
 _status_code_table(other._status_code_table), _mime_type_table(other._mime_type_table),
 _location_info(other._location_info), _resource_abs_path(other._resource_abs_path),
 _route(other._route), _directory_entry(other._directory_entry),
@@ -69,8 +68,6 @@ Response::operator=(const Response& rhs)
 {
     this->_status_code = rhs._status_code;
     this->_headers = rhs._headers;
-    this->_transfer_type = rhs._transfer_type;
-    this->_clients = rhs._clients;
     this->_status_code_table = rhs._status_code_table;
     this->_mime_type_table = rhs._mime_type_table;
     this->_location_info = rhs._location_info;
@@ -562,8 +559,6 @@ Response::init()
 {
     this->_status_code = "200";
     this->_headers = {};
-    this->_transfer_type = "";
-    this->_clients = "";
     this->_location_info = {};
     this->_resource_abs_path = "";
     this->_route = "";
@@ -826,10 +821,10 @@ Response::appendAllowHeader(std::string& headers)
         "HEAD",
         "PUT",
         "DELETE",
-        "CONNECT",
+        // "CONNECT", not implemented
         "OPTIONS",
         "TRACE",
-        "PATCH",
+        // "PATCH", not implemented
     };
 
     headers += "Allow:";
@@ -861,7 +856,7 @@ Response::appendContentLanguageHeader(std::string& headers)
     // NOTE: 만약 요청된 resource가 html, htm 확장자가 있는 파일이 아니면, 
     //       굳이 메타데이터를 추출하지 않도록 구현되어있음.
     std::string extension = this->getUriExtension();
-    if (!(this->isExtensionExist(extension) 
+    if (!(this->ExtensionExists(extension) 
             && this->isExtensionInMimeTypeTable(extension)
             && this->getMimeTypeTable().at(extension).compare("text/html") == 0))
         return ;
@@ -912,7 +907,7 @@ Response::appendContentTypeHeader(std::string& headers)
         std::string extension = this->getUriExtension();
         if (this->getResourceType() == ResType::AUTO_INDEX || this->getResourceType() == ResType::ERROR_HTML)
             headers += "text/html";
-        else if (this->isExtensionExist(extension) && this->isExtensionInMimeTypeTable(extension))
+        else if (this->ExtensionExists(extension) && this->isExtensionInMimeTypeTable(extension))
             headers += this->getMimeTypeTable().at(extension);
         else
             headers += "application/octet-stream";
@@ -1151,7 +1146,7 @@ Response::isAllowedMethod(const std::string& method)
 }
 
 bool
-Response::isExtensionExist(const std::string& extension) const
+Response::ExtensionExists(const std::string& extension) const
 {
     return (extension != "");
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1017,8 +1017,7 @@ Response::makeHeaders(Request& request)
     std::string headers;
     const std::string& method = request.getMethod();
     
-    //TODO 적정 reserve size 구하기
-    headers.reserve(200);
+    headers.reserve(400);
     // General headers
     this->appendDateHeader(headers);
     this->appendServerHeader(headers);


### PR DESCRIPTION
Response.cpp와 Request.cpp에 기재된 TODO들 처리 및 1차적인 리팩토링을 진행했습니다.

#### 1. makeHeaders 실행시 reserve 사이즈를 400으로 설정했습니다.
  - 쉽게 보이는 응답예시 등을 참고하여 응답에 포함되는 헤더의 길이가 400자를 넘지 않는게 보통이라고 판단하였습니다. 속도에는 특기할만한 차이가 없었지만, 그대로 진행하고자 합니다.

#### 2. makeHeaders 함수를 추가되는 header의 성격에 따라 그룹화하는 식으로 가독성을 높였습니다.

#### 3. 고대에 만들어지고 한번도 쓰이지 않은 변수들과 필요없어진 주석들을 삭제처리했습니다.

#### 4. 하드코딩된 값과 매크로 상수를 const 전역변수로 변경하였습니다.

#### 5. Response, Request 객체의 복사생성자, 할당연산자를 삭제하고 private에 넣어서 복사를 막았습니다.