### PR TITLE
Refactor/server

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -102,7 +102,7 @@ public:
     void sendResponse(int fd);
     bool isClientOfServer(int fd) const;
     bool isIndexFileExist(int fd);
-    void findResourceAbsPath(int fd);
+    void parseUriAndSetResponse(int fd);
     bool isAutoIndexOn(int fd);
     bool isCgiUri(int fd, const std::string& extension);
     void checkAndSetResourceType(int fd);

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -46,11 +46,9 @@ private:
     ServerManager* _server_manager;
     std::map<std::string, std::string> _server_config;
     int _server_socket;
-    std::string _server_name;
+    std::string _server_name; // getter 만들어서 로그에서 조지기
     std::string _host;
     std::string _port;
-    int _request_uri_limit_size;
-    int _request_header_limit_size;
     struct sockaddr_in _server_address;
     std::vector<Request> _requests;
     std::map<std::string, location_info> _location_config;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -46,7 +46,6 @@ private:
     ServerManager* _server_manager;
     std::map<std::string, std::string> _server_config;
     int _server_socket;
-    std::string _server_name; // getter 만들어서 로그에서 조지기
     std::string _host;
     std::string _port;
     struct sockaddr_in _server_address;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -101,6 +101,7 @@ public:
     void receiveRequestNormalBody(int fd);
     void receiveRequestChunkedBody(int fd);
     void makeResponseMessage(int fd);
+    void setResponseMessageAccordingToTheParseProgress(int client_fd, std::string& status_line, std::string& headers);
     void sendResponse(int fd);
     bool isClientOfServer(int fd) const;
     bool isIndexFileExist(int fd);

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -73,8 +73,8 @@ Log::serverIsCreated(Server& server)
     int server_fd = server.getServerSocket();
     int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
-    line = ("SERVER(" + std::to_string(server_fd) +
-            ") HAS CREATED\n");
+    line = ("SERVER(" + std::to_string(server_fd) + ")" + "[" +
+            server.getHost() + "] HAS CREATED\n");
     Log::timeLog(fd);
     write(fd, line.c_str(), line.length());
 }
@@ -89,8 +89,8 @@ Log::newClient(Server& server, int client_fd)
     int server_fd = server.getServerSocket();
     int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
-    line = ("SERVER(" + std::to_string(server_fd) +
-            ") HAS NEW CLIENT: " +
+    line = ("SERVER(" + std::to_string(server_fd) +  ")[" +
+            server.getHost() + "] HAS NEW CLIENT: " +
             std::to_string(client_fd) + "\n");
     Log::timeLog(fd);
     write(fd, line.c_str(), line.length());

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1603,12 +1603,10 @@ Server::checkAuthenticate(int client_fd)
     request.setRemoteIdent(after_decode.substr(pos + 1));
 }
 
-//TODO: 함수명이 기능을 담지 못함, 수정 필요함!
-//NOTE: 1. 
 void
-Server::findResourceAbsPath(int client_fd)
+Server::parseUriAndSetResponse(int client_fd)
 {
-    Log::trace("> findResourceAbsPath", 2);
+    Log::trace("> parseUriAndSetResponse", 2);
     timeval from;
     gettimeofday(&from, NULL);
 
@@ -1628,7 +1626,7 @@ Server::findResourceAbsPath(int client_fd)
 
     
     Log::printTimeDiff(from, 2);
-    Log::trace("< findResourceAbsPath", 2);
+    Log::trace("< parseUriAndSetResponse", 2);
 }
 
 void 
@@ -1866,8 +1864,7 @@ Server::processResponseBody(int client_fd)
     timeval from;
     gettimeofday(&from, NULL);
 
-    //NOTE: 수정 필요함
-    this->findResourceAbsPath(client_fd);
+    this->parseUriAndSetResponse(client_fd);
 
     const location_info& location_info = this->_responses[client_fd].getLocationInfo();
     if (location_info.find("limit_client_body_size") != location_info.end())

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -418,6 +418,7 @@ Server::PutFileOnServerErrorException::what() const throw()
 /*********************************  Util  *************************************/ 
 /*============================================================================*/
 
+//TODO: take care init errors
 void
 Server::init()
 {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -20,7 +20,7 @@ std::vector<int> g_child_process_ids(1024, 0);
 
 Server::Server(ServerManager* server_manager, server_info& server_config, std::map<std::string, location_info>& location_config)
 : _server_manager(server_manager), _server_config(server_config),
-_server_socket(-1), _server_name(""), _host(server_config["server_name"]), _port(""),
+_server_socket(-1), _host(server_config["server_name"]), _port(""),
 _location_config(location_config)
 {
     try
@@ -424,7 +424,7 @@ Server::init()
 {
     for (auto& conf: this->_server_config)
     {
-        if (conf.first == "host")
+        if (conf.first == "server_name")
             this->_host = conf.second;
         else if (conf.first == "listen")
             this->_port = conf.second;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -21,7 +21,6 @@ std::vector<int> g_child_process_ids(1024, 0);
 Server::Server(ServerManager* server_manager, server_info& server_config, std::map<std::string, location_info>& location_config)
 : _server_manager(server_manager), _server_config(server_config),
 _server_socket(-1), _server_name(""), _host(server_config["server_name"]), _port(""),
-_request_uri_limit_size(0), _request_header_limit_size(0), 
 _location_config(location_config)
 {
     try
@@ -595,7 +594,7 @@ Server::readBufferUntilHeaders(int client_fd, char* buf, size_t read_target_size
     if ((bytes = read(client_fd, buf, read_target_size)) > 0)
     {
         buf[bytes] = 0;
-        request.appendTempBuffer(buf, bytes); // bytes 가 peeked보다 작을 수 있다.
+        request.appendTempBuffer(buf, bytes);
         return (static_cast<size_t>(bytes) == read_target_size);
     }
     else if (bytes == 0)
@@ -681,7 +680,7 @@ Server::receiveRequestHeaders(int client_fd)
             if (this->readBufferUntilHeaders(client_fd, buf, read_target_size))
             {
                 request.parseRequestHeaders();
-                if (peeked_bytes == read_target_size) // header까지 다읽었는데 버퍼에 남은게 없다.
+                if (peeked_bytes == read_target_size)
                 {
                     if (request.isBodyUnnecessary() ||
                         (request.isNormalBody() && request.getHeaders().at("Content-Length") == "0"))
@@ -905,7 +904,7 @@ Server::receiveRequest(int client_fd)
 
     case RecvRequest::HEADERS:
         this->receiveRequestHeaders(client_fd);
-        // this->processResponseBody()
+        //NOTE: this->processResponseBody()
         break ;
 
     case RecvRequest::NORMAL_BODY:
@@ -1290,8 +1289,6 @@ Server::sendDataToCgi(int write_fd_to_cgi)
         {
             this->_server_manager->fdSet(response.getReadFdFromCgi(), FdSet::READ);
             this->_server_manager->fdClr(write_fd_to_cgi, FdSet::WRITE);
-            //TODO: client_fd를 클리어해줘야하는지 체크 안해줘도 될 것 같은데?
-            // this->_server_manager->fdClr(client_fd, FdSet::READ);
         }
     }
     else if (bytes == 0)
@@ -1506,7 +1503,7 @@ Server::closeClientSocket(int client_fd)
 {
     Response& response = this->_responses[client_fd];
     this->_server_manager->fdClr(client_fd, FdSet::READ);
-    this->_server_manager->fdClr(client_fd, FdSet::WRITE);  //new
+    this->_server_manager->fdClr(client_fd, FdSet::WRITE);
     this->_server_manager->setClosedFdOnFdTable(client_fd);
     this->_server_manager->updateFdMax(client_fd);
 
@@ -1622,17 +1619,11 @@ Server::findResourceAbsPath(int client_fd)
 
     Response& response = this->_responses[client_fd];
     response.setUriPath(path);
-    // extension 확인해서, cgi에 해당하면
-    //   path_info 분리
-    //   cgi script_name 분리
     response.setRouteAndLocationInfo(path, this);
     response.setQuery(parser.getQuery());
     std::string root = response.getLocationInfo().at("root");
-    // if (response.getRoute() != "/")
-    //     root.pop_back();
     std::string file_path = path.substr(response.getRoute().length());
     response.setResourceAbsPath(root + file_path);
-    // /Users/iwoo/Documents/Webserv/YoupiBanane/youpi.bad_extension
 
     
     Log::printTimeDiff(from, 2);
@@ -1854,7 +1845,7 @@ Server::deleteResourceOfUri(int client_fd, const std::string& path)
     }
     else
     {
-        if (errno == ENOTDIR) // dicrectory가 아니다ㅏ. -> unlink
+        if (errno == ENOTDIR)
         {
             if (unlink(path.c_str()) == -1)
                 throw (TargetResourceConflictException(*this, client_fd));

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -96,6 +96,7 @@ ServerGenerator::setDefaultRouteOfServer(std::map<std::string, location_info>& l
     }
 }
 
+//TODO: server generate 중 에러 발생시 catch 해줄 것.
 void 
 ServerGenerator::generateServers(std::vector<Server *>& servers)
 {

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -31,7 +31,6 @@ int main(int argc, char* argv[])
                 server_manager = new_server_manager;
             }
         }
-        
     }
     catch(const std::exception& e)
     {


### PR DESCRIPTION
Server.cpp 에 남겨져있던 TODO들을 처리했습니다.

1. makeResponseMessage 를 리팩토링했습니다.

2. 필요없는 변수와 주석을 삭제했습니다. 

3. 서버네임이 한번 이상은 출력되어야한다는 판단하에 로그 함수를 수정했습니다. 서버생성시나 새로운 클라이언트를 accept할 경우에 서버이름도 함께 출력됩니다.

4. findAndSetAbsPath 함수가 기능을 다 담지 못하는 점을 감안하여 새로 네이밍했습니다.

! init 등 진행하며 발생하는 에러가 throw되면 할당해제 등을 ServerManager 혹은 ServerGenerator가 받아서 처리해줘야합니다. 이 점 감안하여 TODO로 남겼고 sanam과 마저 처리할 예정입니다.