### PR TITLE
FIX: autoindex

### DIFF
--- a/srcs/PageGenerator.cpp
+++ b/srcs/PageGenerator.cpp
@@ -27,8 +27,8 @@ PageGenerator::makeAutoIndex(Response& res)
     body += "<html>\n\t<head>\n\t\t<title>Index of " + res.getRoute() +
         "</title>\n\t</head>\n\t<body>\n\t\t<h1>Index of" + res.getRoute() +
         "</h1>\n\t\t<hr>\n\t\t<pre>";
-    for (auto& s : files)
-        body += "\n\t\t\t<a href=\""+ s +"\">" + s + "</a>";
+    for (auto& file : files)
+        body += "\n\t\t\t<a href=\""+ res.getUriPath() + file +"\">" + file + "</a>";
     body += "\n\t\t</pre>\n\t\t<hr>\n\t</body>\n</html>";
     res.setTransmittingBody(body);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1004,10 +1004,6 @@ Server::sendResponse(int client_fd)
     if (bytes > 0)
     {
         sended_bytes += bytes;
-        // std::cout<<response_message<<std::endl;
-        // std::cout<<"\033[1;44;37m"<<"sended_bytes: "<<sended_bytes<<"\033[0m"<<std::endl;
-        // std::cout<<"\033[1;44;37m"<<"ParseProgress: "<<Log::parseProgressToString(this->_responses[client_fd].getParseProgress())<<"\033[0m"<<std::endl;
-
         sended_response_size += bytes;
         response.setSendedResponseSize(sended_response_size);
         if (sended_response_size == response_message_size)
@@ -1743,6 +1739,8 @@ Server::checkAndSetResourceType(int client_fd)
     DIR* dir_ptr;
     if ((dir_ptr = opendir(response.getResourceAbsPath().c_str())) != NULL)
     {
+        if (response.getUriPath().back() != '/')
+            response.setUriPath(response.getUriPath() + "/");
         response.setDirectoryEntry(dir_ptr);
         closedir(dir_ptr);
         if (method.compare("PUT") == 0)


### PR DESCRIPTION
## 문제

`autoindex`를 켠 상태에서 브라우저로 접근했을 때 문제가 생깁니다.
URI로 `localhost:8080/include` 와 같이 입력하면 해당하는 폴더에 들어가지고 폴더에 있는 파일들의 목록이 브라우저에 보이게 됩니다.
이 때 파일을 누르면 파일의 extension에 따라 동작이 되는데, 우리 서버에서는 404 에러가 발생했었습니다.

## 원인

문제의 원인은 두가지 입니다.
1. PageGenerator 에서 autoindex 를 생성할 때 링크의 주소로 모든 URI를 주는게 아닌 파일의 이름만 주고 있었습니다.
2. `localhost:8080/include` 로 URI를 주면 폴더가 열리기는 하지만 URI의 형태가 파일이기 때문에 `1` 에서 파일의 이름에 주소를 더해줘도 
`includeBase64.o` 와 같이 중간에 슬래쉬가 빠지게 됩니다.

## 해결
1. 링크로 파일의 모든 주소를 주게 했습니다.
2. 해당하는 URI를 OPEN 할 때, 만약 폴더면서 마지막 값이 슬래쉬가 아니라면 인위적으로 슬래쉬를 붙여주게 만들었습니다.