### PR TITLE
Refactor/server run

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -158,6 +158,8 @@ public:
     void finishSendDataToCgiPipe(int write_fd_to_cgi);
     void finishReceiveDataFromCgiPipe(int read_fd_from_cgi);
 
+    void killCgiAndSendErrorToClient(int fd);
+
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException
     {

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -128,6 +128,8 @@ public:
     void acceptClient();
     void openCgiPipe(int fd);
     void forkAndExecuteCgi(int fd);
+
+    void writeSequence(int fd);
     char** makeCgiArgv(int fd);
     char** makeCgiEnvp(int fd);
     bool makeEnvpUsingRequest(char** envp, int fd, int* idx);
@@ -139,6 +141,7 @@ public:
     bool isCgiReadPipe(int fd) const;
     bool isCgiWritePipe(int fd) const;
 
+    void readSequence(int fd);
     void receiveChunkSize(int fd);
     void receiveChunkData(int client_fd, int receive_size);
     void receiveLastChunkData(int fd);
@@ -159,6 +162,7 @@ public:
     void finishReceiveDataFromCgiPipe(int read_fd_from_cgi);
 
     void killCgiAndSendErrorToClient(int fd);
+    void findAndCloseClientSocket(int fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -20,6 +20,7 @@
 
 const int CLIENT_TIME_OUT_SECOND = 5;
 const int CGI_TIME_OUT_SECOND = 60;
+const int DEFAULT_PID = 0;
 
 class Server;
 
@@ -96,6 +97,8 @@ public:
     bool isMonitorTimeOutOn(int fd);
 
     bool isUnresponsiveFd(int fd);
+    bool isCgiProcessTerminated(int clinet_fd) const;
+    void terminateCgiProcess(int client_fd);
     Server* findLinkedServer(int client_fd);
 };
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -645,7 +645,10 @@ Server::receiveRequestLine(int client_fd)
     {
         buf[bytes] = 0;
         if (this->isExistCrlf(client_fd, RecvRequest::REQUEST_LINE))
+        {
             this->readBufferUntilRequestLine(client_fd);
+            this->parseUriAndSetResponse(client_fd);
+        }
         else
             this->findCrlfAndSetIndexOfCrlf(client_fd, buf, RecvRequest::REQUEST_LINE);
     }
@@ -1495,6 +1498,18 @@ Server::run(int fd)
                 }
                 std::cerr << e.what() << '\n';
             }
+            // catch(const std::exception& e)
+            // {
+            //     std::cerr << e.what() << '\n';
+            //     if (this->isCgiReadPipe(fd))
+            //     {
+            //         this->_server_manager->closeCgiReadPipe(*this, fd);
+                    
+            //     }
+            //     else if (this->isStaticResource(fd))
+            //         this->readStaticResource(fd);
+            //     else if (this->isClientSocket(fd))
+            // }
         }
     }
 }
@@ -1863,8 +1878,6 @@ Server::processResponseBody(int client_fd)
     Log::trace("> processResopnseBody", 1);
     timeval from;
     gettimeofday(&from, NULL);
-
-    this->parseUriAndSetResponse(client_fd);
 
     const location_info& location_info = this->_responses[client_fd].getLocationInfo();
     if (location_info.find("limit_client_body_size") != location_info.end())

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1506,33 +1506,17 @@ Server::run(int fd)
                 if (this->isCgiReadPipe(fd))
                 {
                     client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
-                    int write_fd_to_cgi = this->_responses[client_fd].getWriteFdToCgi();
-                    if (write_fd_to_cgi != DEFAULT_FD)
-                        this->_server_manager->closeCgiWritePipe(*this, write_fd_to_cgi);
-                    this->_server_manager->closeCgiReadPipe(*this, fd);
-                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-                    this->_responses[client_fd].setStatusCode("500");
                     kill(this->_responses[client_fd].getCgiPid(), SIGTERM);
+                    g_child_process_ids[client_fd] = 0;
                 }
                 else if (this->isStaticResource(fd))
-                {
                     client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
-                    this->_server_manager->closeStaticResource(*this, fd);
-                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-                    this->_responses[client_fd].setStatusCode("500");
-                }
                 else if (this->isClientSocket(fd))
-                {
                     client_fd = fd;
-                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-                    this->_responses[client_fd].setStatusCode("500");
-                }
                 else
-                {
                     client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
-                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-                    this->_responses[client_fd].setStatusCode("500");
-                }
+                this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+                this->_responses[client_fd].setStatusCode("500");
             }
         }
     }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1469,6 +1469,11 @@ Server::run(int fd)
             {
                 std::cerr << e.what() << '\n';
             }
+            catch(const std::exception& e)
+            {
+                std::cerr << e.what() << '\n';
+                this->findAndCloseClientSocket(fd);
+            }
         }
         else if (this->_server_manager->fdIsCopySet(fd, FdSet::READ))
         {
@@ -2245,4 +2250,17 @@ Server::killCgiAndSendErrorToClient(int fd)
         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
     this->_server_manager->fdSet(client_fd, FdSet::WRITE);
     this->_responses[client_fd].setStatusCode("500");
+}
+
+void
+Server::findAndCloseClientSocket(int fd)
+{
+    int client_fd;
+    if (this->isCgiWritePipe(fd))
+        client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+    else if (this->isClientSocket(fd))
+        client_fd = fd;
+    else
+        client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+    this->closeClientSocket(client_fd);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1475,20 +1475,13 @@ Server::run(int fd)
             try
             {
                 if (this->isCgiReadPipe(fd))
-                {
                     this->receiveDataFromCgi(fd);
-                    throw (std::exception());
-                }
                 else if (this->isStaticResource(fd))
-                {
                     this->readStaticResource(fd);
-                    throw (std::exception());
-                }
                 else if (this->isClientSocket(fd))
                 {
                     this->receiveRequest(fd);
                     Log::getRequest(*this, fd);
-                    throw (std::exception());
                     if (this->_requests[fd].getRecvRequest() == RecvRequest::COMPLETE)
                     {
                         this->_server_manager->fdClr(fd, FdSet::READ);
@@ -1505,42 +1498,42 @@ Server::run(int fd)
                 }
                 std::cerr << e.what() << '\n';
             }
-            // catch(const std::exception& e)
-            // {
-            //     std::cerr << "[CODE 901] std::exception was throwed!\n";
-            //     std::cerr << e.what() << '\n';
-            //     int client_fd;
-            //     if (this->isCgiReadPipe(fd))
-            //     {
-            //         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
-            //         int write_fd_to_cgi = this->_responses[client_fd].getWriteFdToCgi();
-            //         if (write_fd_to_cgi != DEFAULT_FD)
-            //             this->_server_manager->closeCgiWritePipe(*this, write_fd_to_cgi);
-            //         this->_server_manager->closeCgiReadPipe(*this, fd);
-            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-            //         this->_responses[client_fd].setStatusCode("500");
-            //         kill(this->_responses[client_fd].getCgiPid(), SIGTERM);
-            //     }
-            //     else if (this->isStaticResource(fd))
-            //     {
-            //         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
-            //         this->_server_manager->closeStaticResource(*this, fd);
-            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-            //         this->_responses[client_fd].setStatusCode("500");
-            //     }
-            //     else if (this->isClientSocket(fd))
-            //     {
-            //         client_fd = fd;
-            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-            //         this->_responses[client_fd].setStatusCode("500");
-            //     }
-            //     else
-            //     {
-            //         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
-            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
-            //         this->_responses[client_fd].setStatusCode("500");
-            //     }
-            // }
+            catch(const std::exception& e)
+            {
+                std::cerr << "[CODE 901] std::exception was throwed!\n";
+                std::cerr << e.what() << '\n';
+                int client_fd;
+                if (this->isCgiReadPipe(fd))
+                {
+                    client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+                    int write_fd_to_cgi = this->_responses[client_fd].getWriteFdToCgi();
+                    if (write_fd_to_cgi != DEFAULT_FD)
+                        this->_server_manager->closeCgiWritePipe(*this, write_fd_to_cgi);
+                    this->_server_manager->closeCgiReadPipe(*this, fd);
+                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+                    this->_responses[client_fd].setStatusCode("500");
+                    kill(this->_responses[client_fd].getCgiPid(), SIGTERM);
+                }
+                else if (this->isStaticResource(fd))
+                {
+                    client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+                    this->_server_manager->closeStaticResource(*this, fd);
+                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+                    this->_responses[client_fd].setStatusCode("500");
+                }
+                else if (this->isClientSocket(fd))
+                {
+                    client_fd = fd;
+                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+                    this->_responses[client_fd].setStatusCode("500");
+                }
+                else
+                {
+                    client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+                    this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+                    this->_responses[client_fd].setStatusCode("500");
+                }
+            }
         }
     }
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1475,13 +1475,20 @@ Server::run(int fd)
             try
             {
                 if (this->isCgiReadPipe(fd))
+                {
                     this->receiveDataFromCgi(fd);
+                    throw (std::exception());
+                }
                 else if (this->isStaticResource(fd))
+                {
                     this->readStaticResource(fd);
+                    throw (std::exception());
+                }
                 else if (this->isClientSocket(fd))
                 {
                     this->receiveRequest(fd);
                     Log::getRequest(*this, fd);
+                    throw (std::exception());
                     if (this->_requests[fd].getRecvRequest() == RecvRequest::COMPLETE)
                     {
                         this->_server_manager->fdClr(fd, FdSet::READ);
@@ -1500,15 +1507,39 @@ Server::run(int fd)
             }
             // catch(const std::exception& e)
             // {
+            //     std::cerr << "[CODE 901] std::exception was throwed!\n";
             //     std::cerr << e.what() << '\n';
+            //     int client_fd;
             //     if (this->isCgiReadPipe(fd))
             //     {
+            //         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+            //         int write_fd_to_cgi = this->_responses[client_fd].getWriteFdToCgi();
+            //         if (write_fd_to_cgi != DEFAULT_FD)
+            //             this->_server_manager->closeCgiWritePipe(*this, write_fd_to_cgi);
             //         this->_server_manager->closeCgiReadPipe(*this, fd);
-                    
+            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+            //         this->_responses[client_fd].setStatusCode("500");
+            //         kill(this->_responses[client_fd].getCgiPid(), SIGTERM);
             //     }
             //     else if (this->isStaticResource(fd))
-            //         this->readStaticResource(fd);
+            //     {
+            //         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+            //         this->_server_manager->closeStaticResource(*this, fd);
+            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+            //         this->_responses[client_fd].setStatusCode("500");
+            //     }
             //     else if (this->isClientSocket(fd))
+            //     {
+            //         client_fd = fd;
+            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+            //         this->_responses[client_fd].setStatusCode("500");
+            //     }
+            //     else
+            //     {
+            //         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
+            //         this->_server_manager->fdSet(client_fd, FdSet::WRITE);
+            //         this->_responses[client_fd].setStatusCode("500");
+            //     }
             // }
         }
     }

--- a/srcs/ServerGenerator.cpp
+++ b/srcs/ServerGenerator.cpp
@@ -193,7 +193,6 @@ ServerGenerator::generateServers(std::vector<Server *>& servers)
             this->checkValidationOfConfigs(server_config, locations);
             this->setDefaultRouteOfServer(locations, server_config);
             server_block_exists = true;
-            testServerConfig(server_config);
             try
             {
                 Server* server = new Server(this->_server_manager, server_config, locations);

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -472,6 +472,8 @@ ServerManager::terminateCgiProcess(int client_fd)
     if (g_child_process_ids[client_fd] == DEFAULT_PID)
         return ;
     kill(g_child_process_ids[client_fd], SIGTERM);
+    waitpid(g_child_process_ids[client_fd], NULL, 0);
+    std::cout<<"\033[41;1;97m"<<"Server send SIGTERM to process(pid:"<<g_child_process_ids[client_fd]<<")"<<"\033[0m"<<std::endl;
     g_child_process_ids[client_fd] = DEFAULT_PID;
 }
 

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -302,9 +302,9 @@ ServerManager::runServers()
     {
         this->closeUnresponsiveFd();
 
-        std::cout<<"\033[1;44;37m"<<"BEFORE select!"<<"\033[0m"<<std::endl;
-        Log::printFdCopySets(*this, 10);
-        Log::printFdSets(*this, 10);
+        // std::cout<<"\033[1;44;37m"<<"BEFORE select!"<<"\033[0m"<<std::endl;
+        // Log::printFdCopySets(*this, 10);
+        // Log::printFdSets(*this, 10);
         this->_copy_readfds = this->_readfds;
         this->_copy_writefds = this->_writefds;
         this->_copy_exceptfds = this->_exceptfds;
@@ -322,9 +322,9 @@ ServerManager::runServers()
         }
         else
         {
-        std::cout<<"\033[1;44;37m"<<"After select!"<<"\033[0m"<<std::endl;
-        Log::printFdCopySets(*this, 10);
-        Log::printFdSets(*this, 10);
+        // std::cout<<"\033[1;44;37m"<<"After select!"<<"\033[0m"<<std::endl;
+        // Log::printFdCopySets(*this, 10);
+        // Log::printFdSets(*this, 10);
             for (int fd = 0; fd < this->getFdMax() + 1; fd++)
             {
                 if (this->fdIsCopySet(fd, FdSet::ALL))

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -7,7 +7,7 @@
 /****************************  Static variables  ******************************/
 /*============================================================================*/
 
-extern std::vector<int> g_child_process_ids;
+std::vector<int> g_child_process_ids(1024, DEFAULT_PID);
 
 /*============================================================================*/
 /******************************  Constructor  *********************************/
@@ -426,7 +426,7 @@ ServerManager::closeUnresponsiveCgi(int pipe_fd)
                 return ;
             Response& response = server->getResponse(client_fd);
             kill(response.getCgiPid(), SIGTERM);
-            g_child_process_ids[client_fd] = 0;
+            g_child_process_ids[client_fd] = DEFAULT_PID;
             if (response.getSendProgress() == SendProgress::READY)
                 response.setStatusCode("500");
             else
@@ -458,6 +458,21 @@ ServerManager::isUnresponsiveFd(int fd)
         this->fdIsOriginSet(fd, FdSet::WRITE) != this->fdIsCopySet(fd, FdSet::WRITE))
         return (true);
     return (false);
+}
+
+bool
+ServerManager::isCgiProcessTerminated(int client_fd) const
+{
+    return (g_child_process_ids[client_fd] == DEFAULT_PID);
+}
+
+void
+ServerManager::terminateCgiProcess(int client_fd)
+{
+    if (g_child_process_ids[client_fd] == DEFAULT_PID)
+        return ;
+    kill(g_child_process_ids[client_fd], SIGTERM);
+    g_child_process_ids[client_fd] = DEFAULT_PID;
 }
 
 Server*
@@ -571,10 +586,10 @@ ServerManager::exitServers(int signo)
         for (size_t i = 0; i < g_child_process_ids.size(); i++)
         {
             // NOTE: pid is zero, sig is sent to all processes whose group ID is equal to the process group ID to the sender
-            if (g_child_process_ids[i] != 0) 
+            if (g_child_process_ids[i] != DEFAULT_PID) 
             {
                 kill(g_child_process_ids[i], SIGTERM);
-                std::cout<<"server killed pid["<<g_child_process_ids[i]<<"] before exit"<<std::endl;
+                std::cout<<"\nserver killed pid["<<g_child_process_ids[i]<<"] before exit"<<std::endl;
             }
         }
         exit(EXIT_SUCCESS);

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -302,9 +302,9 @@ ServerManager::runServers()
     {
         this->closeUnresponsiveFd();
 
-        // std::cout<<"\033[1;44;37m"<<"BEFORE select!"<<"\033[0m"<<std::endl;
-        // Log::printFdCopySets(*this, 10);
-        // Log::printFdSets(*this, 10);
+        std::cout<<"\033[1;44;37m"<<"BEFORE select!"<<"\033[0m"<<std::endl;
+        Log::printFdCopySets(*this, 10);
+        Log::printFdSets(*this, 10);
         this->_copy_readfds = this->_readfds;
         this->_copy_writefds = this->_writefds;
         this->_copy_exceptfds = this->_exceptfds;
@@ -322,9 +322,9 @@ ServerManager::runServers()
         }
         else
         {
-        // std::cout<<"\033[1;44;37m"<<"After select!"<<"\033[0m"<<std::endl;
-        // Log::printFdCopySets(*this, 10);
-        // Log::printFdSets(*this, 10);
+        std::cout<<"\033[1;44;37m"<<"After select!"<<"\033[0m"<<std::endl;
+        Log::printFdCopySets(*this, 10);
+        Log::printFdSets(*this, 10);
             for (int fd = 0; fd < this->getFdMax() + 1; fd++)
             {
                 if (this->fdIsCopySet(fd, FdSet::ALL))

--- a/tests/iwoo_config2
+++ b/tests/iwoo_config2
@@ -41,7 +41,7 @@ http {
         location /second {
             root /Users/humblego/Documents/dev/team_webserv/tests/;
             index  html;
-            limit_except PUT POST GET
+            limit_except PUT POST GET;
             index index.html index.htm index.abc;
         }
     }


### PR DESCRIPTION
server의 run 함수를 리팩토링하였습니다. 변경점은 아래와 같습니다.

#### 1. `parseUriAndSetResource`의 위치를 변경하였습니다.

이는 요청을 recv할 때 로케이션 블록에 설정된 일정 크기를 넘으면 throw할 수 있도록 하기 위함입니다. 추후 여력이 되면 구현하겠습니다.

#### 2. run 함수를 `readSequence`와 `writeSequence`로 수정하였습니다.

#### 3. 혹시나 run 함수 실행 중 `std::exception`이 throw 될 경우의 catch 구문을 추가하였습니다. 

기존에는 `std::exception`을 catch해주는 구문이 없다보니 `std::exception`이 발생할 경우 서버가 종료되었습니다. 

ex) `std::string`에서 저장할 수 있는 사이즈인 4.2GB 이상의 데이터가 요청에 담겨올 경우,  _body 부분에서 `std::exception`이 throw되고, 서버가 종료되어버림.

이를 방지하기 위해 아래 두 방안을 고려했습니다.
1) recv해온 데이터가 일정 사이즈 이상이 되면 CGI 등으로 넘겨버릴 수 있도록 구조변경
2) `std::exception`가 던져질 경우 catch하여 적절한 처리를 할 수 있도록 수정

개발일정상 후자를 택했고, 혹시나 제가 파악한 내용 외에도 `std::exception`이 던져질 경우를 커버하기 위할 수 있도록 구현했습니다.
결과적으로 아래와 같이 동작합니다.
1) `readSequence`에서 `std::exception`이 throw 될 경우
   - catch하여 client에게 '500' 상태코드를 응답함. 이후 `closeClientSocket` 통해 관련 자원들 반환
2) `writeSequence`에서 `std::exception`이 throw될 경우
  - catch하여 관련 자원들 반환하고 연결을 끊음. (client에게 따로 메세지를 응답하지는 않음.)
