### PR TITLE
Feat/content negotiation

### DIFF
--- a/config/iwoo_config2
+++ b/config/iwoo_config2
@@ -1,6 +1,6 @@
 http { 
     include mime.types;
-    root /Users/humblego/Documents/dev/team_webserv/;
+    root /Users/humblego/Documents/dev/team_webserv/www/;
     server {
         server_name first_server;
         listen       8080;
@@ -8,28 +8,28 @@ http {
         location / {
             limit_except GET;
             cgi .bin .cgi .bla;
-            cgi_path /Users/humblego/Documents/dev/team_webserv/cgi_tester;
+            cgi_path /Users/humblego/Documents/dev/team_webserv/php-mac/bin/php-cgi;
             autoindex on;
-            root /Users/humblego/Documents/dev/team_webserv/;
+            root /Users/humblego/Documents/dev/team_webserv/www/;
         }
         location /put_test {
             limit_except PUT;
             root /Users/humblego/Documents/dev/team_webserv/tests/put_test;
             cgi .bla;
-            cgi_path /Users/humblego/Documents/dev/team_webserv/cgi_tester;
+            cgi_path /Users/humblego/Documents/dev/team_webserv/php-mac/bin/php-cgi;
         }
         location /post_body {
             limit_client_body_size 100;
             limit_except POST;
             index index.html;
-            root /Users/humblego/Documents/dev/team_webserv/tests/folder;
+            root /Users/humblego/Documents/dev/team_webserv/www/folder/;
         }
         location /directory { 
             limit_except GET POST;
             index youpi.bad_extension;
             cgi .bla;
-            cgi_path /Users/humblego/Documents/dev/team_webserv/cgi_tester;
-            root /Users/humblego/Documents/dev/team_webserv/YoupiBanane;
+            cgi_path /Users/humblego/Documents/dev/team_webserv/YoupiBanane/youpi.bad_extension;
+            root /Users/humblego/Documents/dev/team_webserv/YoupiBanane/;
         }
     }
     server {

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -141,6 +141,7 @@ public:
     void checkHeaderIsDuplicated(std::string& key);
 
     bool isCarriegeReturnTrimmed();
+    bool acceptLanguageHeaderExists() const;
 
     void appendBody(char* buf, int bytes);
     void appendBody(const char* buf, int bytes);

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -140,7 +140,7 @@ public:
     void checkSpaceIsValid(std::string& str);
     void checkHeaderIsDuplicated(std::string& key);
 
-    bool isCarriegeReturnTrimmed();
+    bool isCarriegeReturnTrimmed() const;
     bool acceptLanguageHeaderExists() const;
 
     void appendBody(char* buf, int bytes);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -35,6 +35,7 @@ private:
     std::string _uri_extension;
     std::string _transmitting_body;
     std::string _query;
+    std::string _content_language;
 
     size_t _already_encoded_size;
 
@@ -98,6 +99,7 @@ public:
     const std::string& getPathTranslated() const;
     const std::string& getRequestUriForCgi() const;
     const std::string& getQuery() const;
+    const std::string& getContentLanguage() const;
 
     /* Setter */
     void setStatusCode(const std::string& status_code);
@@ -110,6 +112,7 @@ public:
     void setQuery(const std::string& query);
     void setUriExtension(const std::string& extension);
     void setHeaders(const std::string& key, const std::string& value);
+    void setContentLanguage(const std::string& content_language);
 
     void setStdinOfCgi(const int fd);
     void setStdoutOfCgi(const int fd);

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -176,6 +176,10 @@ public:
     bool ExtensionExists(const std::string& extension) const;
     bool isExtensionInMimeTypeTable(const std::string& extension) const;
     void findAndSetUriExtension();
+
+    std::vector<std::string> makeLanguageWeightTable(const std::string& accept_languages);
+    void negotiateContent(const std::string& accept_languages);
+
     bool isNeedToBeChunkedBody(const Request& request) const;
     bool isRedirection(const std::string& status_code) const;
     bool isLocationToBeRedirected() const;

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -194,6 +194,7 @@ public:
     bool isValidSP(std::string& str);
     bool isDuplicatedHeader(std::string& key);
     bool isFileInDirEntry(std::string& index);
+    bool isContentTypeTextHtml() const;
 
     void setTransmittingBody(const std::string& chunked_body);
     void encodeChunkedBody();

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -164,7 +164,6 @@ public:
     void killCgiAndSendErrorToClient(int fd);
     void findAndCloseClientSocket(int fd);
 
-    void negotiateContent(int client_fd);
 
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -164,6 +164,8 @@ public:
     void killCgiAndSendErrorToClient(int fd);
     void findAndCloseClientSocket(int fd);
 
+    void negotiateContent(int client_fd);
+
 public:
     class PayloadTooLargeException : public SendErrorCodeToClientException
     {

--- a/include/UriParser.hpp
+++ b/include/UriParser.hpp
@@ -6,6 +6,7 @@
 # include <vector>
 # include <map>
 # include "utils.hpp"
+# include <algorithm>
 
 class UriParser
 {
@@ -58,6 +59,7 @@ public:
     std::string findPath();
     void print();
     void findAndSetQuery(const std::string& path);
+    std::vector<std::string> makeLanguageWeightTable(const std::string& accept_languages);
 
 };
 

--- a/include/UriParser.hpp
+++ b/include/UriParser.hpp
@@ -59,7 +59,6 @@ public:
     std::string findPath();
     void print();
     void findAndSetQuery(const std::string& path);
-    std::vector<std::string> makeLanguageWeightTable(const std::string& accept_languages);
 
 };
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -802,3 +802,11 @@ Request::isCarriegeReturnTrimmed()
 {
     return (this->getCarriegeReturnTrimmed());
 }
+
+bool
+Request::acceptLanguageHeaderExists() const
+{
+    if (this->_headers.find("Accept-Language") != this->_headers.end())
+        return (true);
+    return (false);
+}

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -798,9 +798,9 @@ Request::checkHeaderIsDuplicated(std::string& key)
 }
 
 bool
-Request::isCarriegeReturnTrimmed()
+Request::isCarriegeReturnTrimmed() const
 {
-    return (this->getCarriegeReturnTrimmed());
+    return (this->_carriege_return_trimmed);
 }
 
 bool

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -803,15 +803,22 @@ Response::appendAllowHeader(std::string& headers)
     headers += "\r\n";
 }
 
+bool
+Response::isContentTypeTextHtml() const
+{
+    if ((this->ExtensionExists(this->_uri_extension) 
+            && this->isExtensionInMimeTypeTable(this->_uri_extension)
+            && this->getMimeTypeTable().at(this->_uri_extension).compare("text/html") == 0))
+        return (true);
+    return (false);
+}
+
 void
 Response::appendContentLanguageHeader(std::string& headers)
 {
     // NOTE: 만약 요청된 resource가 html, htm 확장자가 있는 파일이 아니면, 
     //       굳이 메타데이터를 추출하지 않도록 구현되어있음.
-    std::string extension = this->getUriExtension();
-    if ((this->ExtensionExists(this->_uri_extension) 
-            && this->isExtensionInMimeTypeTable(this->_uri_extension)
-            && this->getMimeTypeTable().at(this->_uri_extension).compare("text/html") == 0))
+    if (this->isContentTypeTextHtml())
     {
         std::string lang_meta_data = this->getHtmlLangMetaData();
         if (lang_meta_data != "")
@@ -1153,7 +1160,7 @@ Response::makeLanguageWeightTable(const std::string& accept_languages)
     for (std::string& s : tmp)
     {
         s = ft::ltrim(s);
-        if ((index =s.find(";q=")) != std::string::npos)
+        if ((index = s.find(";q=")) != std::string::npos)
         {
             double q = std::stod(s.substr(index + 3));
             weight_and_languages.push_back(make_pair(q, s.substr(0, index)));

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -240,6 +240,12 @@ Response::getRequestUriForCgi() const
     return (this->_request_uri_for_cgi);
 }
 
+const std::string&
+Response::getContentLanguage() const
+{
+    return (this->_content_language);
+}
+
 /*============================================================================*/
 /********************************  Setter  ************************************/
 /*============================================================================*/
@@ -373,6 +379,12 @@ Response::setHeaders(const std::string& key, const std::string& value)
 }
 
 void
+Response::setContentLanguage(const std::string& content_language)
+{
+    this->_content_language = content_language;
+}
+
+void
 Response::setSendedResponseSize(const int sended_response_size)
 {
     this->_sended_response_size = sended_response_size;
@@ -450,8 +462,6 @@ Response::setCgiEnvpValues()
         }
     }
 }
-
-
 
 /*============================================================================*/
 /******************************  Exception  ***********************************/
@@ -799,18 +809,22 @@ Response::appendContentLanguageHeader(std::string& headers)
     // NOTE: 만약 요청된 resource가 html, htm 확장자가 있는 파일이 아니면, 
     //       굳이 메타데이터를 추출하지 않도록 구현되어있음.
     std::string extension = this->getUriExtension();
-    if (!(this->ExtensionExists(extension) 
-            && this->isExtensionInMimeTypeTable(extension)
-            && this->getMimeTypeTable().at(extension).compare("text/html") == 0))
-        return ;
-
-    std::string lang_meta_data = this->getHtmlLangMetaData();
-    if (lang_meta_data != "")
+    if ((this->ExtensionExists(this->_uri_extension) 
+            && this->isExtensionInMimeTypeTable(this->_uri_extension)
+            && this->getMimeTypeTable().at(this->_uri_extension).compare("text/html") == 0))
     {
-        headers += "Content-Language: ";
-        headers += lang_meta_data;
-        headers += "\r\n";
+        std::string lang_meta_data = this->getHtmlLangMetaData();
+        if (lang_meta_data != "")
+        {
+            headers += "Content-Language: ";
+            headers += lang_meta_data;
+            headers += "\r\n";
+            return ;
+        }
     }
+    headers += "Content-Language: ";
+    headers += this->getContentLanguage();
+    headers += "\r\n";
 }
 
 void

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -2319,6 +2319,7 @@ Server::negotiateContent(int client_fd)
         if (ft::fileExists(target_content_path))
         {
             response.setResourceAbsPath(target_content_path);
+            response.setContentLanguage(language);
             return ;
         }
     }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1816,6 +1816,8 @@ Server::checkAndSetResourceType(int client_fd)
             throw (CannotOpenDirectoryException(*this, client_fd, "404", errno));
         }
     }
+    if (this->_requests[client_fd].acceptLanguageHeaderExists())
+        this->negotiateContent(client_fd);
 
     Log::printTimeDiff(from, 2);
     Log::trace("< checkAndSetResourceType", 2);
@@ -2284,4 +2286,40 @@ Server::findAndCloseClientSocket(int fd)
     else
         client_fd = this->_server_manager->getLinkedFdFromFdTable(fd);
     this->closeClientSocket(client_fd);
+}
+
+void
+Server::negotiateContent(int client_fd)
+{
+    // 읽은 header 정보를 바탕으로 가중치 테이블 만들기
+    // 폴더엔트리 조사해서 해당하는 파일 있는지 확인
+    // 파일 있으면 path 교체, 없으면 그대로
+
+    UriParser uri_parser;
+    Response& response = this->_responses[client_fd];
+    Request& request = this->_requests[client_fd];
+    const std::string& accpet_languages = request.getHeaders().at("Accept-Language");
+    std::vector<std::string> language_weight_table = uri_parser.makeLanguageWeightTable(accpet_languages);
+
+    size_t index;
+    for (std::string& language : language_weight_table)
+    {
+        //NOTE: en is default.
+        if (language == "en")
+            return ;
+
+        std::string resource_abs_path = response.getResourceAbsPath();
+        if (response.getUriExtension() != "")
+            index = resource_abs_path.rfind(response.getUriExtension());
+        else
+            index = resource_abs_path.length();
+        
+        std::string target_content_path = resource_abs_path.substr(0, index) + "_" + language + response.getUriExtension();
+        
+        if (ft::fileExists(target_content_path))
+        {
+            response.setResourceAbsPath(target_content_path);
+            return ;
+        }
+    }
 }

--- a/srcs/UriParser.cpp
+++ b/srcs/UriParser.cpp
@@ -252,3 +252,33 @@ UriParser::print()
     std::cout << "path: " << this->getPath() << std::endl;
     std::cout << "query: " << this->getQuery() << std::endl;
 }
+
+std::vector<std::string>
+UriParser::makeLanguageWeightTable(const std::string& accept_languages)
+{
+    std::vector<std::pair<double, std::string>> weight_and_languages;
+    std::vector<std::string> tmp = ft::split(accept_languages, ",");
+    size_t count = tmp.size();
+    size_t index;
+    for (std::string& s : tmp)
+    {
+        s = ft::ltrim(s);
+        if ((index =s.find(";q=")) != std::string::npos)
+        {
+            double q = std::stod(s.substr(index + 3));
+            weight_and_languages.push_back(make_pair(q, s.substr(0, index)));
+        }
+        else
+            weight_and_languages.push_back(make_pair(count--, s));
+        
+    }
+
+    sort(weight_and_languages.begin(), weight_and_languages.end());
+
+    std::vector<std::string> language_weight_table;
+    size_t i = weight_and_languages.size();
+    while (i--)
+        language_weight_table.push_back(weight_and_languages[i].second);
+    
+    return (language_weight_table);
+}

--- a/srcs/UriParser.cpp
+++ b/srcs/UriParser.cpp
@@ -252,33 +252,3 @@ UriParser::print()
     std::cout << "path: " << this->getPath() << std::endl;
     std::cout << "query: " << this->getQuery() << std::endl;
 }
-
-std::vector<std::string>
-UriParser::makeLanguageWeightTable(const std::string& accept_languages)
-{
-    std::vector<std::pair<double, std::string>> weight_and_languages;
-    std::vector<std::string> tmp = ft::split(accept_languages, ",");
-    size_t count = tmp.size();
-    size_t index;
-    for (std::string& s : tmp)
-    {
-        s = ft::ltrim(s);
-        if ((index =s.find(";q=")) != std::string::npos)
-        {
-            double q = std::stod(s.substr(index + 3));
-            weight_and_languages.push_back(make_pair(q, s.substr(0, index)));
-        }
-        else
-            weight_and_languages.push_back(make_pair(count--, s));
-        
-    }
-
-    sort(weight_and_languages.begin(), weight_and_languages.end());
-
-    std::vector<std::string> language_weight_table;
-    size_t i = weight_and_languages.size();
-    while (i--)
-        language_weight_table.push_back(weight_and_languages[i].second);
-    
-    return (language_weight_table);
-}

--- a/www/index.html
+++ b/www/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html title="test_lang" lang="ko" class="test_lang">
+<html title="test_lang" lang="en" class="test_lang">
   <head>
     <title>index.html in Webserv directory</title>
     <meta charset="utf-8" />
   </head>
   <body>
-    <h1><a href="index.html">HTML</a></h1>
+    <h1><a href="index.html">HTML(en)</a></h1>
   </body>
 </html>

--- a/www/index_en-US.html
+++ b/www/index_en-US.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html title="test_lang" lang="en-US" class="test_lang">
+  <head>
+    <title>index.html(EN-US) in Webserv directory</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h1><a href="index.html">INDEX(en-US) HTML</a></h1>
+  </body>
+</html>

--- a/www/index_ko.html
+++ b/www/index_ko.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html title="test_lang" lang="ko" class="test_lang">
+  <head>
+    <title>그물대접자 안의 인덱스 에이치티엠엘</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h1><a href="index_ko.html">인덱스 에이치티엠엘</a></h1>
+  </body>
+</html>


### PR DESCRIPTION
### 아래 경우에 콘텐츠 협상이 진행되도록 코드 추가했습니다.
  1. 최초에 요청된 URI의 절대경로에 파일이 존재하며, 
  2. Accept-Language 헤더가 존재할 경우

#### 동작 규칙은 아래와 같습니다.
1. 요청헤더를 파싱하여 언어 가중치 테이블을 구성합니다.
  - 왼쪽에 위치한 언어가 오른쪽에 위치한 가중치 높음.
  - q값이 있는 언어끼리는 q값이 높은 언어가 가중치 높음.
  - ex) `Accept-Language: ko, jp;q=0.2, en:q=0.9, ca`로 요청될 경우, 우선순위는 1. ko, 2. ca, 3. en, 4. jp 순서대로 셋팅됨.

2. 언어 가중치 테이블따라 원래 요청된 URI의 뒤에 `_language`가 붙은 파일을 찾고 존재한다면 그 파일을 반환, 존재하지 않는다면 최초에 요청된 URI의 절대경로에 위치한 파일을 응답합니다. 
단, 기존에 요청한 파일은 애초에 'en' 언어파일이라고 가정합니다.

  - ex) client가 `Accept-Language: ko, jp;q=0.2, en:q=0.9, ca`로 `index.html`을 요청했을 경우, `index_ko.html`,  `index_ca.html`, `index_en.html`, `index.html`, `index_jp.html` 순으로 존재하는지 확인하고 존재하는 파일을 응답함.