### PR TITLE
FIX: updateRecvRequest

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -406,7 +406,7 @@ Request::updateRecvRequest()
     if (this->getMethod() == "" && this->getUri() == "" && this->getVersion() == "")
         this->setRecvRequest(RecvRequest::REQUEST_LINE);
     else if (this->isBodyUnnecessary())
-        this->setRecvRequest(RecvRequest::COMPLETE);
+        throw (RequestFormatException(*this, "400"));
     else if (this->isNormalBody())
         this->setRecvRequest(RecvRequest::NORMAL_BODY);
     else if (this->isChunkedBody())


### PR DESCRIPTION
## [문제 + 원인]

get 메서드에 request body가 있으면 무한루프 발생.

updateRecvRequest 함수에서 바디가 필요하지 않으면 RecvRequest를 COMPLETE으로 변경하여 write 시퀀스로 넘어가지 않았기 때문에 발생했었음.

## [해결]

바디가 필요하지 않으면 RequestFormatException을 throw하게끔 변경.