### PR TITLE
Refactor/authentication

### DIFF
--- a/config/sanam_config
+++ b/config/sanam_config
@@ -1,6 +1,6 @@
 http { 
     include mime.types;
-    root /Users/sanam/Desktop/Webserv/;
+    root /Users/sanam/Desktop/Webserv/www/;
     server {
         server_name first_server;
         listen       8080;
@@ -8,40 +8,48 @@ http {
         location / {
             limit_except GET;
             cgi .bin .cgi .bla;
-            cgi_path /Users/sanam/Desktop/Webserv/cgi_tester;
+            cgi_path /Users/sanam/Desktop/Webserv/php-mac/bin/php-cgi;
             autoindex on;
-            root /Users/sanam/Desktop/Webserv/;
+            root /Users/sanam/Desktop/Webserv/www/;
         }
         location /put_test {
             limit_except PUT;
             root /Users/sanam/Desktop/Webserv/tests/put_test;
             cgi .bla;
-            cgi_path /Users/sanam/Desktop/Webserv/cgi_tester;
+            cgi_path /Users/sanam/Desktop/Webserv/php-mac/bin/php-cgi;
         }
         location /post_body {
             limit_client_body_size 100;
             limit_except POST;
             index index.html;
-            root /Users/sanam/Desktop/Webserv/tests/folder;
+            root /Users/sanam/Desktop/Webserv/www/folder/;
         }
         location /directory { 
+            auth_basic "sanam";
+            auth_basic_user_file /Users/sanam/Desktop/Webserv/.htpassword/sanam;
             limit_except GET POST;
             index youpi.bad_extension;
-            cgi .bla .php;
-            cgi_path /Users/sanam/Desktop/Webserv/cgi_tester;
-            root /Users/sanam/Desktop/Webserv/YoupiBanane;
+            cgi .bla;
+            cgi_path /Users/sanam/Desktop/Webserv/YoupiBanane/youpi.bad_extension;
+            root /Users/sanam/Desktop/Webserv/YoupiBanane/;
         }
     }
     server {
         server_name second_server;
         listen       8081;
+        location / {
+            autoindex on;
+            root /Users/sanam/Desktop/Webserv/www/;
+            auth_basic "sanam";
+            auth_basic_user_file /Users/sanam/Desktop/Webserv/.htpassword/sanam;
+        }
         location /first {
             index  index.html index.htm;
         }
         location /second {
-            root /Users/humblego/Desktop/dev/team_webserv/tests/;
+            root /Users/sanam/Desktop/Webserv/tests/;
             index  html;
-            limit_except PUT POST GET
+            limit_except PUT POST GET;
             index index.html index.htm index.abc;
         }
     }

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -75,7 +75,7 @@ public:
     void setServerSocket();
     void setAuthBasic(const std::string& auth_basic, const std::string& route);
     void setAuthBasicUserFile(const std::string& decoded_id_password, const std::string& route);
-    void setAuthenticateRealm();
+    void setAuthenticateRealms();
 
     /* Exception */
 
@@ -89,6 +89,9 @@ public:
     bool isClientSocket(int fd) const;
     bool isStaticResource(int fd) const;
     bool isCgiPipe(int fd) const;
+    bool isAuthRealm(int fd);
+    bool authorizationHeaderExist(int fd);
+    void checkValidOfAuthHeader(int fd);
 
     /* Server function */
     void init();

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -90,7 +90,7 @@ public:
     bool isStaticResource(int fd) const;
     bool isCgiPipe(int fd) const;
     bool isAuthRealm(int fd);
-    bool authorizationHeaderExist(int fd);
+    bool authorizationHeaderExists(int fd);
     void checkValidOfAuthHeader(int fd);
 
     /* Server function */

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -52,6 +52,7 @@ private:
     std::vector<Request> _requests;
     std::map<std::string, location_info> _location_config;
     std::vector<Response> _responses;
+    std::map<std::string, std::vector<std::string> > _authenticate_realms;
 
 public:
     /* Constructor */
@@ -69,10 +70,12 @@ public:
     Response& getResponse(int fd);
     const std::string& getHost() const;
     const std::string& getPort() const;
+    const std::map<std::string, std::vector<std::string> >& getAuthenticateRealms() const;
     /* Setter */
     void setServerSocket();
     void setAuthBasic(const std::string& auth_basic, const std::string& route);
     void setAuthBasicUserFile(const std::string& decoded_id_password, const std::string& route);
+    void setAuthenticateRealm();
 
     /* Exception */
 
@@ -117,8 +120,6 @@ public:
     void readStaticResource(int fd);
 
     void checkAuthenticate(int fd);
-
-    void setAuthenticateRealm();
 
     void processIfHeadersNotFound(int fd, const std::string& readed);
     void putFileOnServer(int fd);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1628,7 +1628,7 @@ Server::isAuthRealm(int client_fd)
 }
 
 bool
-Server::authorizationHeaderExist(int client_fd)
+Server::authorizationHeaderExists(int client_fd)
 {
     if (this->_requests[client_fd].getHeaders().find("Authorization") ==
             this->_requests[client_fd].getHeaders().end())
@@ -1668,7 +1668,7 @@ Server::checkAuthenticate(int client_fd)
 
     if (this->isAuthRealm(client_fd) == false)
         return ;
-    if (this->authorizationHeaderExist(client_fd) == false)
+    if (this->authorizationHeaderExists(client_fd) == false)
         throw (AuthenticateErrorException(*this, client_fd, "401"));
     this->checkValidOfAuthHeader(client_fd);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1631,10 +1631,9 @@ Server::checkAuthenticate(int client_fd)
     location_info::const_iterator it = location_info.find("auth_basic");
     if (it->second == "off")
         return ;
-    std::map<std::string, std::vector<std::string> >::iterator iter = this->_authenticate_realms.find(route);
-    if (iter == this->_authenticate_realms.end())
+    if (this->_authenticate_realms.find(route) == this->_authenticate_realms.end())
         return ;
-    std::vector<std::string> auths = iter->second;
+    std::vector<std::string> auths = this->_authenticate_realms.find(route)->second;
     const std::map<std::string, std::string>& headers = this->_requests[client_fd].getHeaders();
     it = headers.find("Authorization");
     if (it == headers.end())

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1666,9 +1666,9 @@ Server::checkAuthenticate(int client_fd)
     std::string before_decode;
     std::string after_decode;
 
-    if (!this->isAuthRealm(client_fd))
+    if (this->isAuthRealm(client_fd) == false)
         return ;
-    if (!this->authorizationHeaderExist(client_fd))
+    if (this->authorizationHeaderExist(client_fd) == false)
         throw (AuthenticateErrorException(*this, client_fd, "401"));
     this->checkValidOfAuthHeader(client_fd);
 }


### PR DESCRIPTION
## 문제
얼마전 iwoo님이 하나의 htpasswd 파일에 다수의 user를 등록할 수 있게 수정해주셨는데 서버에서는 다수를 처리하는 부분이 없어서 auth 관련 기능을 사용할 수 없었습니다.

## 해결
Server에 멤버 변수를 하나 추가했습니다. 이 변수는 라우트를 key 로 하고 해당 value로는 auth_file의 id-password가 들어갑니다.
- `std::map<std::string, std::vector<std::string> > _authenticate_realms`

기존에 있던 아래 두 개의 함수를 수정했습니다.
1. `setAuthenticateRealms`
  - 파일을 읽을 때 while 을 사용해서 끝까지 읽는 것을 보장함.
  - 다수의 `id-password` 를 `_authenticate_realms`에 세팅함.
2. `checkAuthenticate`
  - 기존의 함수는 너무 길어서 함수를 3개로 분리했습니다.
    1. `isAuthRealm` - 요청된 uri의 라우트가 보안설정이 되었는지 확인함.
    2. `authrozationHeaderExist` - 요청 헤더에 Auth 헤더가 있는지 확인함.
    3. `checkValidOfAuthHeader` - `authenticate_realms`에 저장된 auth와 요청 auth를 비교함.