### PR TITLE
Fix/delete method

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -44,6 +44,7 @@ namespace ft
     bool IsPrintable(char ch);
 
     bool fileExists(std::string& file_path);
+    std::vector<std::string> makeDirectoryEntry(DIR* dir_ptr);
 }
 
 #endif

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -265,15 +265,7 @@ Response::setResourceAbsPath(const std::string& path)
 void
 Response::setDirectoryEntry(DIR* dir_ptr)
 {
-    this->_directory_entry.clear();
-    struct dirent* entry = NULL;
-    while ((entry = readdir(dir_ptr)) != NULL)
-    {
-        std::string file_path(entry->d_name);
-        if (entry->d_type == 4)
-            file_path += "/";
-        this->_directory_entry.push_back(file_path);
-    }
+    this->_directory_entry = ft::makeDirectoryEntry(dir_ptr);
 }
 
 void

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1906,9 +1906,8 @@ Server::deleteResourceOfUri(int client_fd, const std::string& path)
     {
         if (path.back() != '/')
             throw (CannotOpenDirectoryException(*this, client_fd, "409", errno));
-        response.setDirectoryEntry(dir_ptr);
+        std::vector<std::string> directory_entry = ft::makeDirectoryEntry(dir_ptr);
         closedir(dir_ptr);
-        const std::vector<std::string>& directory_entry = response.getDirectoryEntry();
         for (const std::string& entry : directory_entry)
         {
             if (entry != "./" && entry != "../")
@@ -1916,7 +1915,6 @@ Server::deleteResourceOfUri(int client_fd, const std::string& path)
         }
         if (rmdir(path.c_str()) == -1)
             throw (InternalServerException(*this, client_fd));
-        response.setStatusCode("204");
     }
     else
     {
@@ -1928,7 +1926,7 @@ Server::deleteResourceOfUri(int client_fd, const std::string& path)
         else
             throw (CannotOpenDirectoryException(*this, client_fd, "404", errno));
     }
-
+    response.setStatusCode("204");
     Log::printTimeDiff(from, 2);
     Log::trace("< deleteResourceOfUri", 2);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1916,6 +1916,7 @@ Server::deleteResourceOfUri(int client_fd, const std::string& path)
         }
         if (rmdir(path.c_str()) == -1)
             throw (InternalServerException(*this, client_fd));
+        response.setStatusCode("204");
     }
     else
     {

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -322,5 +322,20 @@ fileExists(std::string& file_path)
     return (true);
 }
 
+std::vector<std::string>
+makeDirectoryEntry(DIR* dir_ptr)
+{
+    std::vector<std::string> directory_entry;
+    struct dirent* entry = NULL;
+    while ((entry = readdir(dir_ptr)) != NULL)
+    {
+        std::string file_path(entry->d_name);
+        if (entry->d_type == 4)
+            file_path += "/";
+        directory_entry.push_back(file_path);
+    }
+    return (directory_entry);
+}
+
 
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -330,7 +330,7 @@ makeDirectoryEntry(DIR* dir_ptr)
     while ((entry = readdir(dir_ptr)) != NULL)
     {
         std::string file_path(entry->d_name);
-        if (entry->d_type == 4)
+        if (entry->d_type == DT_DIR)
             file_path += "/";
         directory_entry.push_back(file_path);
     }


### PR DESCRIPTION
# 문제

##   1. delete 이  성공하면 200 status_code가  세팅되고 있었습니다. rfc7231에 따르면
  ```
  a 204 (No Content) status code if the
     action has been enacted and no further information is to be supplied,
     or a 200 (OK) status code if the action has been enacted and the
     response message includes a representation describing the status.
  ```
삭제에 성공하고 이 상황에 대한 설명이 응답 메시지에 포함되지 않으면 `204`로 세팅하라고 되어있습니다.
그리고 우리 서버는 삭제 성공했을 때 응답 메시지가 없기 때문에 204로 세팅하는게 맞다고 판단했고 수정했습니다.

## 2. netsted 폴더를 delete 하면 서버가 터짐
서버가 터지는 이유는 `deleteResourceOfUri` 함수가 재귀적으로 동작하는데 삭제하는 `directory_entry`가 공용으로 사용되었기 때문입니다.

# 해결
1.  `deleteResourceOfUri` 에서 성공하면 `204` 를 세팅해줬습니다.
2. `makeDirectoryEntry` 라는 함수를 만들어서 `deleteResourceOfUri` 함수가 실행될 때 마다 파일 엔트리를 만들어 줬습니다.

# 기타
- 유틸함수로 파일엔트리를 만드는 `makeDirectoryEntry`를 만들었습니다.
- `response`의 `setDirectoryEntry` 내부에서 `1` 에서 만든 함수를 사용하도록 수정했습니다.