### PR TITLE
Feat/log at

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -Wall -Wextra -Werror -std=c++11 -fsanitize=address -g
 RM = rm -rf
 
 # 1 일 때 디폴트 에러 로그, 2일 때 trace로그 추가
-DEBUG = -D DEBUG=1
+DEBUG = -D DEBUG=0
 STDOUT = -D STDOUT=1
 
 MAIN_FILES = main PageGenerator Log utils ServerManager ServerGenerator Server Response Request UriParser Exception Base64

--- a/config/sanam_config
+++ b/config/sanam_config
@@ -1,6 +1,10 @@
 http { 
     include mime.types;
     root /Users/sanam/Desktop/Webserv/www/;
+    plugins accept_language echo_in_location show_fd_table check_timeout log_at;
+    client_timeout_second 10;
+    cgi_timeout_second 180;
+    log_at log.txt;
     server {
         server_name first_server;
         listen       8080;

--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -17,8 +17,7 @@ private:
     Log& operator=(const Log& rhs);
 
 public:
-    static int access_fd;
-    static int error_fd;
+    static int log_fd;
     
     // access
     static void serverIsCreated(Server& server);

--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -48,6 +48,7 @@ public:
     static void printFdCopySets(ServerManager& server_manager, int width);
     static void printFdSets(ServerManager& server_manager, int width);
     static void printTimeSec(timeval& tv);
+    static bool isLogPluginOn();
 };
 
 #endif

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -109,6 +109,7 @@ public:
     Server* findLinkedServer(int client_fd);
 
     bool isPluginOn(const std::string& plugin_name) const;
+    void setLogFd() const;
 };
 
 #endif

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -12,7 +12,6 @@
 int
 Log::log_fd = -1;
 
-
 /*============================================================================*/
 /******************************  Destructor  **********************************/
 /*============================================================================*/
@@ -202,7 +201,6 @@ Log::error(const std::string& error)
     write(Log::log_fd, error.c_str(), error.length());
 }
 
-
 void
 Log::printTimeDiff(timeval from, int log_level)
 {
@@ -222,7 +220,6 @@ Log::trace(const std::string& trace, int log_level)
     if (DEBUG < log_level)
         return ;
     std::string line;
-    Log::timeLog(1);
     write(1, trace.c_str(), trace.length());
     write(1, "\n", 1);
 }

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -10,17 +10,8 @@
 /*============================================================================*/
 
 int
-Log::access_fd= -1;
+Log::log_fd = -1;
 
-int
-Log::error_fd = -1;
-// int
-// Log::access_fd = open("./log/access_log",
-//         O_CREAT | O_TRUNC | O_WRONLY, 0644);
-//
-// int
-// Log::error_fd = open("./log/error_log",
-//         O_CREAT | O_TRUNC | O_WRONLY, 0644);
 
 /*============================================================================*/
 /******************************  Destructor  **********************************/
@@ -45,7 +36,7 @@ Log::error_fd = -1;
 bool
 Log::isLogPluginOn()
 {
-    if (Log::access_fd == -1)
+    if (Log::log_fd == -1)
         return (false);
     return (true);
 }
@@ -87,8 +78,8 @@ Log::serverIsCreated(Server& server)
 
     line = ("SERVER(" + std::to_string(server_fd) + ")" + "[" +
             server.getHost() + "] HAS CREATED\n");
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, line.c_str(), line.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, line.c_str(), line.length());
 }
 
 void
@@ -103,8 +94,8 @@ Log::newClient(Server& server, int client_fd)
     line = ("SERVER(" + std::to_string(server_fd) +  ")[" +
             server.getHost() + "] HAS NEW CLIENT: " +
             std::to_string(client_fd) + "\n");
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, line.c_str(), line.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, line.c_str(), line.length());
 }
 
 void
@@ -115,13 +106,12 @@ Log::closeClient(Server& server, int client_fd)
 
     std::string line;
     int server_fd = server.getServerSocket();
-    // int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
     line = ("SERVER(" + std::to_string(server_fd) +
             ") BYBY CLIENT(" + std::to_string(client_fd)
            + ")\n");
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, line.c_str(), line.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, line.c_str(), line.length());
 }
 
 void
@@ -137,8 +127,8 @@ Log::openFd(Server& server, int client_socket, const FdType& type, int fd)
                     + ") which requested by CLIENT(" 
                     + std::to_string(client_socket) + ")\n";
 
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, line.c_str(), line.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, line.c_str(), line.length());
 }
 
 void
@@ -155,8 +145,8 @@ Log::closeFd(Server& server, int client_socket, const FdType& type, int fd)
                     + ") which requested by CLIENT(" 
                     + std::to_string(client_socket) + ")\n";
 
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, line.c_str(), line.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, line.c_str(), line.length());
 }
 
 void
@@ -170,8 +160,8 @@ Log::closeFd(const FdType& type, int fd)
                     + fdTypeToString(type) + "(" + std::to_string(fd) 
                     + ") which requested by CLIENT\n";
 
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, line.c_str(), line.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, line.c_str(), line.length());
 }
 
 void
@@ -198,8 +188,8 @@ Log::getRequest(Server& server, int client_fd)
         line = ("SERVER(" + std::to_string(server_fd) + ") READ CLIENT(" +
         std::to_string(client_fd) + ") BUFFER BUT EMPTY NOW\n"); 
     }
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, line.c_str(), line.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, line.c_str(), line.length());
 }
 
 void
@@ -208,8 +198,8 @@ Log::error(const std::string& error)
     if (Log::isLogPluginOn() == false)
         return ;
 
-    Log::timeLog(Log::access_fd);
-    write(Log::access_fd, error.c_str(), error.length());
+    Log::timeLog(Log::log_fd);
+    write(Log::log_fd, error.c_str(), error.length());
 }
 
 

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -10,12 +10,17 @@
 /*============================================================================*/
 
 int
-Log::access_fd = open("./log/access_log",
-        O_CREAT | O_TRUNC | O_WRONLY, 0644);
+Log::access_fd= -1;
 
 int
-Log::error_fd = open("./log/error_log",
-        O_CREAT | O_TRUNC | O_WRONLY, 0644);
+Log::error_fd = -1;
+// int
+// Log::access_fd = open("./log/access_log",
+//         O_CREAT | O_TRUNC | O_WRONLY, 0644);
+//
+// int
+// Log::error_fd = open("./log/error_log",
+//         O_CREAT | O_TRUNC | O_WRONLY, 0644);
 
 /*============================================================================*/
 /******************************  Destructor  **********************************/
@@ -36,6 +41,14 @@ Log::error_fd = open("./log/error_log",
 /*============================================================================*/
 /*********************************  Util  *************************************/
 /*============================================================================*/
+
+bool
+Log::isLogPluginOn()
+{
+    if (Log::access_fd == -1)
+        return (false);
+    return (true);
+}
 
 void
 Log::timeLog(int fd)
@@ -66,80 +79,75 @@ Log::printTimeSec(timeval& tv)
 void
 Log::serverIsCreated(Server& server)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
 
     std::string line;
     int server_fd = server.getServerSocket();
-    int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
     line = ("SERVER(" + std::to_string(server_fd) + ")" + "[" +
             server.getHost() + "] HAS CREATED\n");
-    Log::timeLog(fd);
-    write(fd, line.c_str(), line.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, line.c_str(), line.length());
 }
 
 void
 Log::newClient(Server& server, int client_fd)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
 
     std::string line;
     int server_fd = server.getServerSocket();
-    int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
     line = ("SERVER(" + std::to_string(server_fd) +  ")[" +
             server.getHost() + "] HAS NEW CLIENT: " +
             std::to_string(client_fd) + "\n");
-    Log::timeLog(fd);
-    write(fd, line.c_str(), line.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, line.c_str(), line.length());
 }
 
 void
 Log::closeClient(Server& server, int client_fd)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
 
     std::string line;
     int server_fd = server.getServerSocket();
-    int fd = (STDOUT == 1) ? 1 : Log::access_fd;
+    // int fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
     line = ("SERVER(" + std::to_string(server_fd) +
             ") BYBY CLIENT(" + std::to_string(client_fd)
            + ")\n");
-    Log::timeLog(fd);
-    write(fd, line.c_str(), line.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, line.c_str(), line.length());
 }
 
 void
 Log::openFd(Server& server, int client_socket, const FdType& type, int fd)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
 
     int server_fd = server.getServerSocket();
-    int log_print_fd = (STDOUT == 1) ? 1 : Log::access_fd;
-
     std::string line;
     line = "SERVER(" + std::to_string(server_fd) + ") OPEN " 
                     + fdTypeToString(type) + "(" + std::to_string(fd) 
                     + ") which requested by CLIENT(" 
                     + std::to_string(client_socket) + ")\n";
 
-    Log::timeLog(log_print_fd);
-    write(log_print_fd, line.c_str(), line.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, line.c_str(), line.length());
 }
 
 void
 Log::closeFd(Server& server, int client_socket, const FdType& type, int fd)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
 
     int server_fd = server.getServerSocket();
-    int log_print_fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
     std::string line;
     line = "SERVER(" + std::to_string(server_fd) + ") CLOSE " 
@@ -147,36 +155,33 @@ Log::closeFd(Server& server, int client_socket, const FdType& type, int fd)
                     + ") which requested by CLIENT(" 
                     + std::to_string(client_socket) + ")\n";
 
-    Log::timeLog(log_print_fd);
-    write(log_print_fd, line.c_str(), line.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, line.c_str(), line.length());
 }
 
 void
 Log::closeFd(const FdType& type, int fd)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
-
-    int log_print_fd = (STDOUT == 1) ? 1 : Log::access_fd;
 
     std::string line;
     line = "SEVER CLOSES " 
                     + fdTypeToString(type) + "(" + std::to_string(fd) 
                     + ") which requested by CLIENT\n";
 
-    Log::timeLog(log_print_fd);
-    write(log_print_fd, line.c_str(), line.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, line.c_str(), line.length());
 }
 
 void
 Log::getRequest(Server& server, int client_fd)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
 
     std::string line;
     int server_fd = server.getServerSocket();
-    int fd = (STDOUT == 1) ? 1 : Log::access_fd;
     std::string method = server.getRequest(client_fd).getMethod();
     std::string uri = server.getRequest(client_fd).getUri();
     std::string version = server.getRequest(client_fd).getVersion();
@@ -193,34 +198,32 @@ Log::getRequest(Server& server, int client_fd)
         line = ("SERVER(" + std::to_string(server_fd) + ") READ CLIENT(" +
         std::to_string(client_fd) + ") BUFFER BUT EMPTY NOW\n"); 
     }
-    Log::timeLog(fd);
-    write(fd, line.c_str(), line.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, line.c_str(), line.length());
 }
 
 void
 Log::error(const std::string& error)
 {
-    if (DEBUG == 0)
+    if (Log::isLogPluginOn() == false)
         return ;
 
-    int fd = (STDOUT == 1) ? 1 : Log::error_fd;
-    Log::timeLog(fd);
-    write(fd, error.c_str(), error.length());
+    Log::timeLog(Log::access_fd);
+    write(Log::access_fd, error.c_str(), error.length());
 }
 
 
 void
 Log::printTimeDiff(timeval from, int log_level)
 {
+    if (DEBUG < log_level)
+        return ;
     timeval t;
     gettimeofday(&t, NULL);
     std::string diff = std::to_string((t.tv_sec - from.tv_sec) * 1000000 + (t.tv_usec - from.tv_usec));
     diff.push_back(' ');
 
-    if (DEBUG < log_level)
-        return ;
-    int fd = (STDOUT == 1) ? 1 : Log::access_fd;
-    write(fd, diff.c_str(), diff.length());
+    write(1, diff.c_str(), diff.length());
 }
 
 void
@@ -228,13 +231,10 @@ Log::trace(const std::string& trace, int log_level)
 {
     if (DEBUG < log_level)
         return ;
-
     std::string line;
-    int fd = (STDOUT == 1) ? 1 : Log::access_fd;
-
-    // Log::timeLog(fd);
-    write(fd, trace.c_str(), trace.length());
-    write(fd, "\n", 1);
+    Log::timeLog(1);
+    write(1, trace.c_str(), trace.length());
+    write(1, "\n", 1);
 }
 
 std::string

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -674,10 +674,10 @@ ServerManager::setLogFd() const
         if (plugins.find("log_at") != plugins.end())
         {
             if (plugins["log_at"] == "STDOUT")
-                Log::access_fd= 1;
+                Log::log_fd= 1;
             else
             {
-                Log::access_fd= open(plugins["log_at"].c_str(),
+                Log::log_fd= open(plugins["log_at"].c_str(),
                         O_CREAT | O_TRUNC | O_WRONLY, 0644);
             }
         }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -674,10 +674,10 @@ ServerManager::setLogFd() const
         if (plugins.find("log_at") != plugins.end())
         {
             if (plugins["log_at"] == "STDOUT")
-                Log::log_fd= 1;
+                Log::log_fd = 1;
             else
             {
-                Log::log_fd= open(plugins["log_at"].c_str(),
+                Log::log_fd = open(plugins["log_at"].c_str(),
                         O_CREAT | O_TRUNC | O_WRONLY, 0644);
             }
         }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -175,7 +175,11 @@ ServerManager::setPlugins(std::map<std::string, std::string>& http_config)
         if (plugin == "log_at")
         {
             if (http_config.find("log_at") != http_config.end())
+            {
                 this->_plugins[plugin] = http_config["log_at"];
+                if (this->_plugins[plugin] == ";")
+                    this->_plugins[plugin] = "STDOUT";
+            }
             else
                 this->_plugins[plugin] = "STDOUT";
         }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -326,12 +326,12 @@ ServerManager::updateFdMax(int fd)
 /************************  Manage Server functions  ***************************/
 /*============================================================================*/
 
-
 void
 ServerManager::initServers()
 {
     ServerGenerator server_generator(this);
     server_generator.generateServers(this->_servers);
+    this->setLogFd();
 }
 
 bool
@@ -663,4 +663,23 @@ ServerManager::isPluginOn(const std::string& plugin_name) const
     if (this->_plugins.find(plugin_name) != this->_plugins.end())
         return (true);
     return (false);
+}
+
+void
+ServerManager::setLogFd() const
+{
+    std::map<std::string, std::string> plugins = this->getPlugins();
+    if (this->isPluginOn("log_at"))
+    {
+        if (plugins.find("log_at") != plugins.end())
+        {
+            if (plugins["log_at"] == "STDOUT")
+                Log::access_fd= 1;
+            else
+            {
+                Log::access_fd= open(plugins["log_at"].c_str(),
+                        O_CREAT | O_TRUNC | O_WRONLY, 0644);
+            }
+        }
+    }
 }

--- a/srcs/ServerManager.cpp
+++ b/srcs/ServerManager.cpp
@@ -672,16 +672,16 @@ ServerManager::isPluginOn(const std::string& plugin_name) const
 void
 ServerManager::setLogFd() const
 {
-    std::map<std::string, std::string> plugins = this->getPlugins();
+    const std::map<std::string, std::string>& plugins = this->getPlugins();
     if (this->isPluginOn("log_at"))
     {
         if (plugins.find("log_at") != plugins.end())
         {
-            if (plugins["log_at"] == "STDOUT")
+            if (plugins.at("log_at") == "STDOUT")
                 Log::log_fd = 1;
             else
             {
-                Log::log_fd = open(plugins["log_at"].c_str(),
+                Log::log_fd = open(plugins.at("log_at").c_str(),
                         O_CREAT | O_TRUNC | O_WRONLY, 0644);
             }
         }


### PR DESCRIPTION
## 문제
로그 플러그인의 추가. 만약 로그 플러그인이 셋 되어 있다면, 사용자가 지정한 파일 또는 STDOUT으로 로그가 나와야 함

## 해결
- `isLogPluginOn` 이라는 `bool` 함수를 만들어서 입력이 사용자가 로그 플러그인을 설정하지 않은 경우에는 로그가 출력되지 않게 합니다.
- `trace` 들은 log 플러그인과 관계 없이, `Makefile` 에서 `DEBUG` 값에 의해 출력이 됩니다. 그리고 출력은 `STDOUT`으로 되게 만들었습니다. 만약 trace 출력을 원치 않는다면 `DEBUG`를 0 으로 하면 됩니다.



