### PR TITLE
make plugin loadable/unloadable through terminal

### DIFF
--- a/RunServer.sh
+++ b/RunServer.sh
@@ -14,7 +14,12 @@ elif [ ${res} -eq ${SERVER_RUN} ]; then
     echo "======================="
     echo ">> PUT CONFIG FILE NAME"
     read config_file_name
-    echo ">>> Servers will run with ${config_file_name}"
+    echo ">>> Servers will run with config flie - ${config_file_name}"
+    echo ">> PUT PLUGIN NAMES"
+    read plugin_names
+    echo ">>> Servers will run with plugins - ${plugin_names}"
+    sed "s/plugin_names/${plugin_names}/" ./config/${config_file_name} > ./config/.temp_config 
     make
-    ./Webserv ./config/${config_file_name}
+    ./Webserv ./config/.temp_config
+    rm ./config/.temp_config
 fi

--- a/config/iwoo_config2
+++ b/config/iwoo_config2
@@ -1,7 +1,7 @@
 http { 
     include mime.types;
     root /Users/humblego/Documents/dev/team_webserv/www/;
-    plugins accept_language echo_in_location show_fd_table check_timeout log_at;
+    plugins plugin_names;
     client_timeout_second 10;
     cgi_timeout_second 180;
     log_at log.txt;
@@ -13,7 +13,7 @@ http {
             limit_except GET;
             cgi .bin .cgi .bla;
             cgi_path /Users/humblego/Documents/dev/team_webserv/php-mac/bin/php-cgi;
-            echo "Hello world!";
+            location_msg "Hello world!";
             autoindex on;
             root /Users/humblego/Documents/dev/team_webserv/www/;
         }


### PR DESCRIPTION
플러그인을 터미널을 통해 load 하거나 unload 할 수 있게 만들라는 것이 서브젝트 요구사항이었습니다.
크게 구조를 바꿀 필요없이 Runserver 쉘스크립트를 수정하여 요구사항을 충족시켰습니다.

동작은 아래와 같습니다.
1. 이제 Runserver 쉘스크립트를 통해 설정파일 이름을 입력하면,
server를 구동시키는데 참조하는 설정파일을 복사한 `./config/.temp_config` 파일이 만들어집니다.

 2. 이어서 Runserver 쉘스크립트를 통해 플러그인 이름을 입력하면,
`./config/.temp_config` 파일의 `plugin_names`이 기 입력한 플러그인 이름들로 치환됩니다.

 3. 이후 최종적으로 셋팅이 완료된 `./config/.temp_config` 파일을 참조하여 서버가 구동됩니다.